### PR TITLE
Implement password hashing on registration

### DIFF
--- a/src/main/java/com/example/demo/service/LoginRegistServiceImpl.java
+++ b/src/main/java/com/example/demo/service/LoginRegistServiceImpl.java
@@ -1,6 +1,9 @@
 package com.example.demo.service;
 
 import org.springframework.stereotype.Service;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import com.example.demo.entity.User;
 import com.example.demo.repository.LoginRepository;
@@ -11,11 +14,26 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LoginRegistServiceImpl implements LoginRegistService {
 	
-	private final LoginRepository repository;
+        private final LoginRepository repository;
 
-	@Override
-	public void userRegist(User user) {
-		repository.add(user);
-	}
+        @Override
+        public void userRegist(User user) {
+                user.setPassword(hashPassword(user.getPassword()));
+                repository.add(user);
+        }
+
+        private String hashPassword(String password) {
+                try {
+                        MessageDigest md = MessageDigest.getInstance("SHA-256");
+                        byte[] hashed = md.digest(password.getBytes(StandardCharsets.UTF_8));
+                        StringBuilder sb = new StringBuilder();
+                        for (byte b : hashed) {
+                                sb.append(String.format("%02x", b));
+                        }
+                        return sb.toString();
+                } catch (NoSuchAlgorithmException e) {
+                        throw new RuntimeException("Could not hash password", e);
+                }
+        }
 
 }


### PR DESCRIPTION
## Summary
- hash new user passwords using SHA-256 before persisting them

## Testing
- `mvnw -q test` *(fails: network access blocked for Maven)*

------
https://chatgpt.com/codex/tasks/task_e_6856c5a7a650832abc297ef8035f280f