### PR TITLE
Add navigation links to task top page

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -123,3 +123,10 @@ td {
 .review-list {
     background-color: #afeeee;
 }
+
+/* リンクエリアを画面左上に配置 */
+.link-area {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+}

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -3,9 +3,15 @@
 <head>
 <meta charset="UTF-8">
 <title>トップ画面</title>
+<link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body>
-	<p><b>トップ画面</b></p>
+        <div class="link-area">
+                <a href="challenge-box.html">challenge-box.html</a><br>
+                <a href="question-survey-box.html">question-survey-box.html</a><br>
+                <a href="task-box.html">task-box.html</a>
+        </div>
+        <p><b>トップ画面</b></p>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link to challenge, question survey and task boxes from `task-top.html`
- style `link-area` for top-left positioning

## Testing
- `./mvnw test -q` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6856e611d81c832a9cebc28680310fec