### PR TITLE
Improve link area styling

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -129,4 +129,20 @@ td {
     position: absolute;
     top: 10px;
     left: 10px;
+    border: 2px solid #5e696c;
+    padding: 10px;
+    background-color: #fff;
+    border-radius: 8px;
+}
+
+.link-area a {
+    display: block;
+    margin-bottom: 5px;
+    color: steelblue;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.link-area a:hover {
+    text-decoration: underline;
 }

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -7,9 +7,9 @@
 </head>
 <body>
         <div class="link-area">
-                <a href="challenge-box.html">challenge-box.html</a><br>
-                <a href="question-survey-box.html">question-survey-box.html</a><br>
-                <a href="task-box.html">task-box.html</a>
+                <a href="challenge-box.html">挑戦ボックス</a>
+                <a href="question-survey-box.html">疑問・調査ボックス</a>
+                <a href="task-box.html">タスクボックス</a>
         </div>
         <p><b>トップ画面</b></p>
 


### PR DESCRIPTION
## Summary
- style the link area container with a border and background
- show each link as a block element with hover effect
- rename links to 日本語 titles

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e8893968832a9c99b0eb5b544d68