### PR TITLE
Add calendar to task top page

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -146,3 +146,26 @@ td {
 .link-area a:hover {
     text-decoration: underline;
 }
+
+/* カレンダーを画面右上に配置 */
+.calendar-area {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    border: 2px solid #5e696c;
+    padding: 10px;
+    background-color: #fff;
+    border-radius: 8px;
+}
+
+.calendar-area table {
+    border-collapse: collapse;
+}
+
+.calendar-area th,
+.calendar-area td {
+    border: 1px solid #5e696c;
+    width: 30px;
+    height: 24px;
+    text-align: center;
+}

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -11,7 +11,44 @@
                 <a href="question-survey-box.html">疑問・調査ボックス</a>
                 <a href="task-box.html">タスクボックス</a>
         </div>
+        <div id="calendar" class="calendar-area"></div>
         <p><b>トップ画面</b></p>
+
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const container = document.getElementById('calendar');
+            const today = new Date();
+            const year = today.getFullYear();
+            const month = today.getMonth(); // 0-based
+
+            const firstDay = new Date(year, month, 1).getDay();
+            const lastDate = new Date(year, month + 1, 0).getDate();
+
+            let html = '<table>';
+            html += '<tr><th colspan="7">' + year + '年' + (month + 1) + '月</th></tr>';
+            html += '<tr><th>日</th><th>月</th><th>火</th><th>水</th><th>木</th><th>金</th><th>土</th></tr><tr>';
+
+            for (let i = 0; i < firstDay; i++) {
+                html += '<td></td>';
+            }
+
+            for (let day = 1; day <= lastDate; day++) {
+                if ((firstDay + day - 1) % 7 === 0 && day !== 1) {
+                    html += '</tr><tr>';
+                }
+                html += '<td>' + day + '</td>';
+            }
+
+            const remaining = (firstDay + lastDate) % 7;
+            if (remaining !== 0) {
+                for (let i = 0; i < 7 - remaining; i++) {
+                    html += '<td></td>';
+                }
+            }
+            html += '</tr></table>';
+            container.innerHTML = html;
+        });
+        </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a calendar of the current month in the upper-right corner of task-top page
- style the calendar for placement and formatting

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f040105c832a86d56420b2e8ff7a