### PR TITLE
Change calendar start and highlight today

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -169,3 +169,8 @@ td {
     height: 24px;
     text-align: center;
 }
+
+/* 本日の日付を赤枠で強調 */
+.calendar-area .today {
+    border: 2px solid red;
+}

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -22,23 +22,28 @@
 	           const year = today.getFullYear();
 	           const month = today.getMonth(); // 0-based
 
-	           const firstDay = new Date(year, month, 1).getDay();
-	           const lastDate = new Date(year, month + 1, 0).getDate();
+                   // Monday を週の開始とするため、
+                   // getDay() の結果 (0:日曜) を1つ左へシフト
+                   const firstDay = (new Date(year, month, 1).getDay() + 6) % 7;
+                   const lastDate = new Date(year, month + 1, 0).getDate();
 
 	           let html = '<table>';
 	           html += '<tr><th colspan="7">' + year + '年' + (month + 1) + '月</th></tr>';
-	           html += '<tr><th>日</th><th>月</th><th>火</th><th>水</th><th>木</th><th>金</th><th>土</th></tr><tr>';
+                   // 表示順を月曜始まりに変更
+                   html += '<tr><th>月</th><th>火</th><th>水</th><th>木</th><th>金</th><th>土</th><th>日</th></tr><tr>';
 
-	           for (let i = 0; i < firstDay; i++) {
-	               html += '<td></td>';
-	           }
+                   for (let i = 0; i < firstDay; i++) {
+                       html += '<td></td>';
+                   }
 
-	           for (let day = 1; day <= lastDate; day++) {
-	               if ((firstDay + day - 1) % 7 === 0 && day !== 1) {
-	                   html += '</tr><tr>';
-	               }
-	               html += '<td>' + day + '</td>';
-	           }
+                   for (let day = 1; day <= lastDate; day++) {
+                       if ((firstDay + day - 1) % 7 === 0 && day !== 1) {
+                           html += '</tr><tr>';
+                       }
+                       const isToday = day === today.getDate();
+                       const cls = isToday ? ' class="today"' : '';
+                       html += '<td' + cls + '>' + day + '</td>';
+                   }
 
 	           const remaining = (firstDay + lastDate) % 7;
 	           if (remaining !== 0) {


### PR DESCRIPTION
## Summary
- start calendar week from Monday
- highlight today's date with a red border

## Testing
- `./mvnw -q test` *(fails: Permission denied / missing Maven due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856f68d402c832a85f84126660e590f