### PR TITLE
Display tasks on top page

### DIFF
--- a/src/main/java/com/example/demo/controller/LoginController.java
+++ b/src/main/java/com/example/demo/controller/LoginController.java
@@ -15,8 +15,8 @@ import lombok.RequiredArgsConstructor;
 @Controller
 @RequiredArgsConstructor
 public class LoginController {
-	
-	private final LoginRegistService service;
+
+        private final LoginRegistService loginService;
 	
 	
 	
@@ -30,22 +30,22 @@ public class LoginController {
 		return "new-regist";
 	}
 	
-	@PostMapping("/log-in")
-	public String reShowLogInForm(NewRegistForm form) {
-		User u=new User();
-		u.setUsername(form.getNewUsername());
-		u.setPassword(form.getNewPassword());
-		service.userRegist(u);
-		return "log-in";
-	}
+        @PostMapping("/log-in")
+        public String reShowLogInForm(NewRegistForm form) {
+                User u=new User();
+                u.setUsername(form.getNewUsername());
+                u.setPassword(form.getNewPassword());
+                loginService.userRegist(u);
+                return "log-in";
+        }
 	
     @PostMapping("/task-top")
     public String showTop(LogInForm form, Model model) {
             User u = new User();
             u.setUsername(form.getUsername());
             u.setPassword(form.getPassword());
-            if (service.login(u)) {
-                    return "task-top";
+            if (loginService.login(u)) {
+                    return "redirect:/task-top";
             } else {
                     model.addAttribute("errorMessage", "ログイン失敗");
                     return "log-in";

--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -1,16 +1,22 @@
 package com.example.demo.controller;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.example.demo.service.TaskService;
 
 import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequiredArgsConstructor
 public class TaskListController {
-	
-//	private final TaskListService service;
-	
-	 
-	
 
+    private final TaskService service;
+
+    @GetMapping("/task-top")
+    public String showTaskTop(Model model) {
+        model.addAttribute("tasks", service.getAllTasks());
+        return "task-top";
+    }
 }

--- a/src/main/java/com/example/demo/entity/Task.java
+++ b/src/main/java/com/example/demo/entity/Task.java
@@ -1,0 +1,12 @@
+package com.example.demo.entity;
+
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class Task {
+    private String taskName;
+    private LocalDate dueDate;
+    private boolean confirmed;
+}

--- a/src/main/java/com/example/demo/repository/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/TaskRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.repository;
+
+import java.util.List;
+
+import com.example.demo.entity.Task;
+
+public interface TaskRepository {
+    List<Task> findAll();
+}

--- a/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.example.demo.repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.Task;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TaskRepositoryImpl implements TaskRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<Task> findAll() {
+        String sql = "SELECT task_name, due_date, confirmed FROM tasks";
+        return jdbcTemplate.query(sql, new RowMapper<Task>() {
+            @Override
+            public Task mapRow(ResultSet rs, int rowNum) throws SQLException {
+                Task t = new Task();
+                t.setTaskName(rs.getString("task_name"));
+                LocalDate date = rs.getDate("due_date").toLocalDate();
+                t.setDueDate(date);
+                t.setConfirmed(rs.getBoolean("confirmed"));
+                return t;
+            }
+        });
+    }
+}

--- a/src/main/java/com/example/demo/service/TaskService.java
+++ b/src/main/java/com/example/demo/service/TaskService.java
@@ -1,0 +1,9 @@
+package com.example.demo.service;
+
+import java.util.List;
+
+import com.example.demo.entity.Task;
+
+public interface TaskService {
+    List<Task> getAllTasks();
+}

--- a/src/main/java/com/example/demo/service/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TaskServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.demo.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.Task;
+import com.example.demo.repository.TaskRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TaskServiceImpl implements TaskService {
+
+    private final TaskRepository repository;
+
+    @Override
+    public List<Task> getAllTasks() {
+        return repository.findAll();
+    }
+}

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -14,6 +14,22 @@
         </div>
 		<div id="calendar" class="calendar-area"></div>
         <p><b>トップ画面</b></p>
+
+        <div>
+                <table>
+                        <tr>
+                                <th>Task Name</th>
+                                <th>Due Date</th>
+                                <th>Confirmed</th>
+                        </tr>
+                        <tr th:each="task : ${tasks}">
+                                <td th:text="${task.taskName}"></td>
+                                <td th:text="${task.dueDate}"></td>
+                                <td th:text="${task.confirmed}"></td>
+                        </tr>
+                </table>
+        </div>
+
         <script th:src="@{/js/calende.js}"></script>
 		
 </body>


### PR DESCRIPTION
## Summary
- show tasks in the center of `task-top.html`
- load tasks from the DB using service and repository layers
- redirect to task list after login

## Testing
- `mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685707852fdc832a8bfc27d20e92a1b3