### PR TITLE
Add checkbox for confirmed tasks

### DIFF
--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -25,7 +25,9 @@
                         <tr th:each="task : ${tasks}">
                                 <td th:text="${task.taskName}"></td>
                                 <td th:text="${task.dueDate}"></td>
-                                <td th:text="${task.confirmed}"></td>
+                                <td>
+                                        <input type="checkbox" th:checked="${task.confirmed}" disabled>
+                                </td>
                         </tr>
                 </table>
         </div>


### PR DESCRIPTION
## Summary
- show task confirmation with a checkbox in the task list

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f1d79150832aa62e549dbdf65932