### PR TITLE
Allow updating confirmed flag

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -3,6 +3,9 @@ package com.example.demo.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.example.demo.service.TaskService;
 
@@ -18,5 +21,12 @@ public class TaskListController {
     public String showTaskTop(Model model) {
         model.addAttribute("tasks", service.getAllTasks());
         return "task-top";
+    }
+
+    @PostMapping("/task/confirm")
+    @ResponseBody
+    public void updateConfirmed(@RequestParam("name") String taskName,
+                                @RequestParam("checked") boolean confirmed) {
+        service.updateConfirmed(taskName, confirmed);
     }
 }

--- a/src/main/java/com/example/demo/repository/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/TaskRepository.java
@@ -6,4 +6,6 @@ import com.example.demo.entity.Task;
 
 public interface TaskRepository {
     List<Task> findAll();
+
+    void updateConfirmed(String taskName, boolean confirmed);
 }

--- a/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
@@ -34,4 +34,10 @@ public class TaskRepositoryImpl implements TaskRepository {
             }
         });
     }
+
+    @Override
+    public void updateConfirmed(String taskName, boolean confirmed) {
+        String sql = "UPDATE tasks SET confirmed = ? WHERE task_name = ?";
+        jdbcTemplate.update(sql, confirmed, taskName);
+    }
 }

--- a/src/main/java/com/example/demo/service/TaskService.java
+++ b/src/main/java/com/example/demo/service/TaskService.java
@@ -6,4 +6,6 @@ import com.example.demo.entity.Task;
 
 public interface TaskService {
     List<Task> getAllTasks();
+
+    void updateConfirmed(String taskName, boolean confirmed);
 }

--- a/src/main/java/com/example/demo/service/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TaskServiceImpl.java
@@ -19,4 +19,9 @@ public class TaskServiceImpl implements TaskService {
     public List<Task> getAllTasks() {
         return repository.findAll();
     }
+
+    @Override
+    public void updateConfirmed(String taskName, boolean confirmed) {
+        repository.updateConfirmed(taskName, confirmed);
+    }
 }

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.confirm-checkbox').forEach(cb => {
+        cb.addEventListener('change', event => {
+            const name = event.target.getAttribute('data-name');
+            const checked = event.target.checked;
+            fetch('/task/confirm', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                body: `name=${encodeURIComponent(name)}&checked=${checked}`
+            });
+        });
+    });
+});

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -25,12 +25,17 @@
                         <tr th:each="task : ${tasks}">
                                 <td th:text="${task.taskName}"></td>
                                 <td th:text="${task.dueDate}"></td>
-                                <td th:text="${task.confirmed}"></td>
+                                <td>
+                                    <input type="checkbox" class="confirm-checkbox"
+                                           th:attr="data-name=${task.taskName}"
+                                           th:checked="${task.confirmed}">
+                                </td>
                         </tr>
                 </table>
         </div>
 
         <script th:src="@{/js/calende.js}"></script>
+        <script th:src="@{/js/task.js}"></script>
 		
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable editing the `confirmed` flag for tasks
- send change to backend via new endpoint
- update repository/service/controller for saving confirmation state
- render a checkbox for each task
- include front-end script to post updates

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f337e3b8832a80b27165efbbaca7