### PR TITLE
Enable task confirmation toggle

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -3,8 +3,12 @@ package com.example.demo.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.http.ResponseEntity;
 
 import com.example.demo.service.TaskService;
+import com.example.demo.entity.Task;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,5 +22,11 @@ public class TaskListController {
     public String showTaskTop(Model model) {
         model.addAttribute("tasks", service.getAllTasks());
         return "task-top";
+    }
+
+    @PostMapping("/task-confirm")
+    public ResponseEntity<Void> updateConfirmed(@RequestBody Task task) {
+        service.updateConfirmed(task.getTaskName(), task.getDueDate(), task.isConfirmed());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/demo/repository/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/TaskRepository.java
@@ -1,9 +1,12 @@
 package com.example.demo.repository;
 
 import java.util.List;
+import java.time.LocalDate;
 
 import com.example.demo.entity.Task;
 
 public interface TaskRepository {
     List<Task> findAll();
+
+    void updateConfirmed(String taskName, LocalDate dueDate, boolean confirmed);
 }

--- a/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
@@ -34,4 +34,10 @@ public class TaskRepositoryImpl implements TaskRepository {
             }
         });
     }
+
+    @Override
+    public void updateConfirmed(String taskName, LocalDate dueDate, boolean confirmed) {
+        String sql = "UPDATE tasks SET confirmed = ? WHERE task_name = ? AND due_date = ?";
+        jdbcTemplate.update(sql, confirmed, taskName, java.sql.Date.valueOf(dueDate));
+    }
 }

--- a/src/main/java/com/example/demo/service/TaskService.java
+++ b/src/main/java/com/example/demo/service/TaskService.java
@@ -1,9 +1,12 @@
 package com.example.demo.service;
 
 import java.util.List;
+import java.time.LocalDate;
 
 import com.example.demo.entity.Task;
 
 public interface TaskService {
     List<Task> getAllTasks();
+
+    void updateConfirmed(String taskName, LocalDate dueDate, boolean confirmed);
 }

--- a/src/main/java/com/example/demo/service/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TaskServiceImpl.java
@@ -1,6 +1,7 @@
 package com.example.demo.service;
 
 import java.util.List;
+import java.time.LocalDate;
 
 import org.springframework.stereotype.Service;
 
@@ -18,5 +19,10 @@ public class TaskServiceImpl implements TaskService {
     @Override
     public List<Task> getAllTasks() {
         return repository.findAll();
+    }
+
+    @Override
+    public void updateConfirmed(String taskName, LocalDate dueDate, boolean confirmed) {
+        repository.updateConfirmed(taskName, dueDate, confirmed);
     }
 }

--- a/src/main/resources/static/js/tasks.js
+++ b/src/main/resources/static/js/tasks.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.confirm-box').forEach(cb => {
+        cb.addEventListener('change', () => {
+            const data = {
+                taskName: cb.dataset.name,
+                dueDate: cb.dataset.date,
+                confirmed: cb.checked
+            };
+            fetch('/task-confirm', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            });
+        });
+    });
+});

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -25,14 +25,16 @@
                         <tr th:each="task : ${tasks}">
                                 <td th:text="${task.taskName}"></td>
                                 <td th:text="${task.dueDate}"></td>
-								<td>
-                                    <input type="checkbox" th:checked="${task.confirmed}" disabled>
+                                <td>
+                                    <input type="checkbox" th:checked="${task.confirmed}" class="confirm-box"
+                                        th:data-name="${task.taskName}" th:data-date="${task.dueDate}">
                                 </td>
                         </tr>
                 </table>
         </div>
 
         <script th:src="@{/js/calende.js}"></script>
+        <script th:src="@{/js/tasks.js}"></script>
 		
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow editing of `confirmed` checkbox
- persist checkbox changes to `tasks` table
- add client script to send AJAX updates

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_6857f8e5a0c4832a97b8bc75c0f1192b