### PR TITLE
Add calendar task display

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -165,9 +165,14 @@ td {
 .calendar-area th,
 .calendar-area td {
     border: 1px solid #5e696c;
-    width: 30px;
-    height: 24px;
+    width: 40px;
+    height: 32px;
     text-align: center;
+    vertical-align: top;
+}
+
+.calendar-area td .tasks div {
+    font-size: 10px;
 }
 
 /* 本日の日付を赤枠で強調 */

--- a/src/main/resources/static/js/tasks.js
+++ b/src/main/resources/static/js/tasks.js
@@ -1,5 +1,47 @@
 document.addEventListener('DOMContentLoaded', () => {
+    const calendar = document.getElementById('calendar');
+    const dayCells = {};
+    calendar.querySelectorAll('td').forEach(td => {
+        const day = parseInt(td.textContent, 10);
+        if (!isNaN(day)) {
+            dayCells[day] = td;
+        }
+    });
+
+    function addTask(name, dateStr) {
+        const date = new Date(dateStr);
+        const cell = dayCells[date.getDate()];
+        if (!cell) return;
+        let wrapper = cell.querySelector('.tasks');
+        if (!wrapper) {
+            wrapper = document.createElement('div');
+            wrapper.className = 'tasks';
+            cell.appendChild(wrapper);
+        }
+        const item = document.createElement('div');
+        item.textContent = name;
+        item.dataset.name = name;
+        wrapper.appendChild(item);
+    }
+
+    function removeTask(name, dateStr) {
+        const date = new Date(dateStr);
+        const cell = dayCells[date.getDate()];
+        if (!cell) return;
+        const wrapper = cell.querySelector('.tasks');
+        if (!wrapper) return;
+        wrapper.querySelectorAll('div').forEach(div => {
+            if (div.dataset.name === name) {
+                div.remove();
+            }
+        });
+    }
+
     document.querySelectorAll('.task-confirm-box').forEach(cb => {
+        if (cb.checked) {
+            addTask(cb.dataset.name, cb.dataset.date);
+        }
+
         cb.addEventListener('change', () => {
             const data = {
                 taskName: cb.dataset.name,
@@ -13,6 +55,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 },
                 body: JSON.stringify(data)
             });
+
+            if (cb.checked) {
+                addTask(cb.dataset.name, cb.dataset.date);
+            } else {
+                removeTask(cb.dataset.name, cb.dataset.date);
+            }
         });
     });
 });


### PR DESCRIPTION
## Summary
- enlarge calendar boxes and allow tasks to be listed within them
- show confirmed tasks on the calendar

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858111be4cc832aa59bd32c6bb9a33b