### PR TITLE
Enable due date editing

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -29,4 +29,10 @@ public class TaskListController {
         service.updateConfirmed(task);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/task-due-date")
+    public ResponseEntity<Void> updateDueDate(@RequestBody Task task) {
+        service.updateDueDate(task);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/demo/repository/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/TaskRepository.java
@@ -8,4 +8,6 @@ public interface TaskRepository {
     List<Task> findAll();
 
     void updateConfirmed(Task task);
+
+    void updateDueDate(Task task);
 }

--- a/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
@@ -40,4 +40,10 @@ public class TaskRepositoryImpl implements TaskRepository {
         String sql = "UPDATE tasks SET confirmed = ? WHERE task_name = ? AND due_date = ?";
         jdbcTemplate.update(sql, task.isConfirmed(), task.getTaskName(), java.sql.Date.valueOf(task.getDueDate()));
     }
+
+    @Override
+    public void updateDueDate(Task task) {
+        String sql = "UPDATE tasks SET due_date = ? WHERE task_name = ?";
+        jdbcTemplate.update(sql, java.sql.Date.valueOf(task.getDueDate()), task.getTaskName());
+    }
 }

--- a/src/main/java/com/example/demo/service/TaskService.java
+++ b/src/main/java/com/example/demo/service/TaskService.java
@@ -8,4 +8,6 @@ public interface TaskService {
     List<Task> getAllTasks();
 
     void updateConfirmed(Task task);
+
+    void updateDueDate(Task task);
 }

--- a/src/main/java/com/example/demo/service/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TaskServiceImpl.java
@@ -24,4 +24,9 @@ public class TaskServiceImpl implements TaskService {
     public void updateConfirmed(Task task) {
         repository.updateConfirmed(task);
     }
+
+    @Override
+    public void updateDueDate(Task task) {
+        repository.updateDueDate(task);
+    }
 }

--- a/src/main/resources/static/js/tasks.js
+++ b/src/main/resources/static/js/tasks.js
@@ -63,4 +63,29 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     });
+
+    document.querySelectorAll('.due-date-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const data = {
+                taskName: inp.dataset.name,
+                dueDate: inp.value
+            };
+            fetch('/task-due-date', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            });
+
+            const cb = document.querySelector('.task-confirm-box[data-name="' + inp.dataset.name + '"]');
+            if (cb) {
+                if (cb.checked) {
+                    removeTask(cb.dataset.name, cb.dataset.date);
+                    addTask(cb.dataset.name, inp.value);
+                }
+                cb.dataset.date = inp.value;
+            }
+        });
+    });
 });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -24,7 +24,9 @@
                         </tr>
                         <tr th:each="task : ${tasks}">
                                 <td th:text="${task.taskName}"></td>
-                                <td th:text="${task.dueDate}"></td>
+                                <td>
+                                    <input type="date" th:value="${task.dueDate}" class="due-date-input" th:data-name="${task.taskName}">
+                                </td>
                                 <td>
                                     <input type="checkbox" th:checked="${task.confirmed}" class="task-confirm-box"
                                         th:data-name="${task.taskName}" th:data-date="${task.dueDate}">


### PR DESCRIPTION
## Summary
- allow editing due dates in task list
- persist updates via controller/service/repository
- update JS to send due date changes and update calendar

## Testing
- `./mvnw -q test` *(fails: failed to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685813584598832aa51849a9eb87738a