### PR TITLE
Add task name update

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -6,6 +6,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import com.example.demo.form.TaskNameUpdate;
 
 import com.example.demo.entity.Task;
 import com.example.demo.service.TaskService;
@@ -33,6 +34,12 @@ public class TaskListController {
     @PostMapping("/task-due-date")
     public ResponseEntity<Void> updateDueDate(@RequestBody Task task) {
         service.updateDueDate(task);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/task-name")
+    public ResponseEntity<Void> updateTaskName(@RequestBody TaskNameUpdate req) {
+        service.updateTaskName(req.getOldTaskName(), req.getNewTaskName());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/demo/form/TaskNameUpdate.java
+++ b/src/main/java/com/example/demo/form/TaskNameUpdate.java
@@ -1,0 +1,9 @@
+package com.example.demo.form;
+
+import lombok.Data;
+
+@Data
+public class TaskNameUpdate {
+    private String oldTaskName;
+    private String newTaskName;
+}

--- a/src/main/java/com/example/demo/repository/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/TaskRepository.java
@@ -10,4 +10,6 @@ public interface TaskRepository {
     void updateConfirmed(Task task);
 
     void updateDueDate(Task task);
+
+    void updateTaskName(String oldTaskName, String newTaskName);
 }

--- a/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/TaskRepositoryImpl.java
@@ -46,4 +46,10 @@ public class TaskRepositoryImpl implements TaskRepository {
         String sql = "UPDATE tasks SET due_date = ? WHERE task_name = ?";
         jdbcTemplate.update(sql, java.sql.Date.valueOf(task.getDueDate()), task.getTaskName());
     }
+
+    @Override
+    public void updateTaskName(String oldTaskName, String newTaskName) {
+        String sql = "UPDATE tasks SET task_name = ? WHERE task_name = ?";
+        jdbcTemplate.update(sql, newTaskName, oldTaskName);
+    }
 }

--- a/src/main/java/com/example/demo/service/TaskService.java
+++ b/src/main/java/com/example/demo/service/TaskService.java
@@ -10,4 +10,6 @@ public interface TaskService {
     void updateConfirmed(Task task);
 
     void updateDueDate(Task task);
+
+    void updateTaskName(String oldTaskName, String newTaskName);
 }

--- a/src/main/java/com/example/demo/service/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/TaskServiceImpl.java
@@ -29,4 +29,9 @@ public class TaskServiceImpl implements TaskService {
     public void updateDueDate(Task task) {
         repository.updateDueDate(task);
     }
+
+    @Override
+    public void updateTaskName(String oldTaskName, String newTaskName) {
+        repository.updateTaskName(oldTaskName, newTaskName);
+    }
 }

--- a/src/main/resources/static/js/tasks.js
+++ b/src/main/resources/static/js/tasks.js
@@ -88,4 +88,36 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     });
+
+    document.querySelectorAll('.task-name-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const data = {
+                oldTaskName: inp.dataset.oldName,
+                newTaskName: inp.value
+            };
+            fetch('/task-name', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            });
+
+            const cb = document.querySelector('.task-confirm-box[data-name="' + inp.dataset.oldName + '"]');
+            if (cb) {
+                if (cb.checked) {
+                    removeTask(cb.dataset.name, cb.dataset.date);
+                    addTask(inp.value, cb.dataset.date);
+                }
+                cb.dataset.name = inp.value;
+            }
+
+            const dd = document.querySelector('.due-date-input[data-name="' + inp.dataset.oldName + '"]');
+            if (dd) {
+                dd.dataset.name = inp.value;
+            }
+
+            inp.dataset.oldName = inp.value;
+        });
+    });
 });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -23,7 +23,9 @@
                                 <th>Confirmed</th>
                         </tr>
                         <tr th:each="task : ${tasks}">
-                                <td th:text="${task.taskName}"></td>
+                                <td>
+                                    <input type="text" th:value="${task.taskName}" class="task-name-input" th:data-old-name="${task.taskName}">
+                                </td>
                                 <td>
                                     <input type="date" th:value="${task.dueDate}" class="due-date-input" th:data-name="${task.taskName}">
                                 </td>


### PR DESCRIPTION
## Summary
- allow editing task names in task list
- update DB when task name changes
- keep calendar in sync with new task names

## Testing
- `./mvnw -o -q test` *(fails: repository download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6858154630c8832a89ec91a5e29e39b1