### PR TITLE
Add month navigation to calendar

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -179,3 +179,18 @@ td {
 .calendar-area .today {
     border: 2px solid red;
 }
+
+/* navigation buttons */
+.calendar-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+}
+
+.calendar-nav button {
+    background: none;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+}

--- a/src/main/resources/static/js/calende.js
+++ b/src/main/resources/static/js/calende.js
@@ -1,40 +1,70 @@
-// Calendar script from task-top.html
+// Calendar with month navigation
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', () => {
     const container = document.getElementById('calendar');
-    const today = new Date();
-    const year = today.getFullYear();
-    const month = today.getMonth(); // 0-based
 
-    // Monday を週の開始とするため、
-    // getDay() の結果 (0:日曜) を1つ左へシフト
-    const firstDay = (new Date(year, month, 1).getDay() + 6) % 7;
-    const lastDate = new Date(year, month + 1, 0).getDate();
+    container.innerHTML = `
+        <div class="calendar-nav">
+            <button id="prev-month">\u2190</button>
+            <span id="calendar-title"></span>
+            <button id="next-month">\u2192</button>
+        </div>
+        <div id="calendar-table"></div>
+    `;
 
-    let html = '<table>';
-    html += '<tr><th colspan="7">' + year + '年' + (month + 1) + '月</th></tr>';
-    // 表示順を月曜始まりに変更
-    html += '<tr><th>月</th><th>火</th><th>水</th><th>木</th><th>金</th><th>土</th><th>日</th></tr><tr>';
+    const titleEl = container.querySelector('#calendar-title');
+    const tableWrap = container.querySelector('#calendar-table');
+    let current = new Date();
 
-    for (let i = 0; i < firstDay; i++) {
-        html += '<td></td>';
-    }
+    function renderCalendar(year, month) {
+        const today = new Date();
+        const firstDay = (new Date(year, month, 1).getDay() + 6) % 7;
+        const lastDate = new Date(year, month + 1, 0).getDate();
 
-    for (let day = 1; day <= lastDate; day++) {
-        if ((firstDay + day - 1) % 7 === 0 && day !== 1) {
-            html += '</tr><tr>';
-        }
-        const isToday = day === today.getDate();
-        const cls = isToday ? ' class="today"' : '';
-        html += '<td' + cls + '>' + day + '</td>';
-    }
+        let html = '<table>';
+        html += '<tr><th>月</th><th>火</th><th>水</th><th>木</th><th>金</th><th>土</th><th>日</th></tr><tr>';
 
-    const remaining = (firstDay + lastDate) % 7;
-    if (remaining !== 0) {
-        for (let i = 0; i < 7 - remaining; i++) {
+        for (let i = 0; i < firstDay; i++) {
             html += '<td></td>';
         }
+
+        for (let day = 1; day <= lastDate; day++) {
+            if ((firstDay + day - 1) % 7 === 0 && day !== 1) {
+                html += '</tr><tr>';
+            }
+            const isToday =
+                day === today.getDate() &&
+                month === today.getMonth() &&
+                year === today.getFullYear();
+            const cls = isToday ? ' class="today"' : '';
+            html += '<td' + cls + '>' + day + '</td>';
+        }
+
+        const remaining = (firstDay + lastDate) % 7;
+        if (remaining !== 0) {
+            for (let i = 0; i < 7 - remaining; i++) {
+                html += '<td></td>';
+            }
+        }
+        html += '</tr></table>';
+        tableWrap.innerHTML = html;
+        titleEl.textContent = `${year}年${month + 1}月`;
+        document.dispatchEvent(new Event('calendarRendered'));
     }
-    html += '</tr></table>';
-    container.innerHTML = html;
+
+    function changeMonth(offset) {
+        current.setMonth(current.getMonth() + offset);
+        renderCalendar(current.getFullYear(), current.getMonth());
+    }
+
+    container.addEventListener('click', (e) => {
+        if (e.target.id === 'prev-month') {
+            changeMonth(-1);
+        } else if (e.target.id === 'next-month') {
+            changeMonth(1);
+        }
+    });
+
+    renderCalendar(current.getFullYear(), current.getMonth());
 });
+

--- a/src/main/resources/static/js/tasks.js
+++ b/src/main/resources/static/js/tasks.js
@@ -1,12 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
     const calendar = document.getElementById('calendar');
-    const dayCells = {};
-    calendar.querySelectorAll('td').forEach(td => {
-        const day = parseInt(td.textContent, 10);
-        if (!isNaN(day)) {
-            dayCells[day] = td;
-        }
-    });
+    let dayCells = {};
+
+    function mapDayCells() {
+        dayCells = {};
+        calendar.querySelectorAll('td').forEach(td => {
+            const day = parseInt(td.textContent, 10);
+            if (!isNaN(day)) {
+                dayCells[day] = td;
+            }
+        });
+    }
+
+    function initTasks() {
+        mapDayCells();
+        document.querySelectorAll('.task-confirm-box').forEach(cb => {
+            if (cb.checked) {
+                addTask(cb.dataset.name, cb.dataset.date);
+            }
+        });
+    }
 
     function addTask(name, dateStr) {
         const date = new Date(dateStr);
@@ -120,4 +133,8 @@ document.addEventListener('DOMContentLoaded', () => {
             inp.dataset.oldName = inp.value;
         });
     });
+
+    initTasks();
+    document.addEventListener('calendarRendered', initTasks);
 });
+


### PR DESCRIPTION
## Summary
- add prev/next buttons for the calendar
- support calendar re-render with JavaScript
- refresh task display when month changes
- style navigation buttons

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685922a8d2e0832a898dacc9ae3cf1d9