### PR TITLE
Enable editing schedule date

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.schedule-date-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const date = new Date(inp.value);
+            if (isNaN(date.getTime())) return;
+            const dow = date.toLocaleDateString('ja-JP', { weekday: 'short' });
+            const row = inp.closest('tr');
+            if (row) {
+                const dayField = row.querySelector('.schedule-day-of-week');
+                if (dayField) {
+                    dayField.value = dow;
+                }
+            }
+        });
+    });
+});

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -59,6 +59,21 @@
                                 <td>
                                     <input type="text" th:value="${schedule.title}">
                                 </td>
+                                <td>
+                                    <input type="date" th:value="${schedule.scheduleDate}" class="schedule-date-input">
+                                </td>
+                                <td>
+                                    <input type="text" th:value="${schedule.dayOfWeek}" class="schedule-day-of-week" readonly>
+                                </td>
+                                <td>
+                                    <input type="time" th:value="${schedule.startTime}">
+                                </td>
+                                <td>
+                                    <input type="time" th:value="${schedule.endTime}">
+                                </td>
+                                <td>
+                                    <input type="text" th:value="${schedule.location}">
+                                </td>
                         </tr>
                 </table>
         </div>
@@ -67,6 +82,7 @@
 
         <script th:src="@{/js/calende.js}"></script>
         <script th:src="@{/js/tasks.js}"></script>
+        <script th:src="@{/js/schedule.js}"></script>
 		
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow editing of schedule date on task top page
- display weekday from date automatically using client-side script

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594a2c61f8832a8ca06bd992a2f55d