### PR TITLE
Support 5 minute intervals for schedule times

### DIFF
--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -66,10 +66,10 @@
                                     <input type="text" th:value="${schedule.dayOfWeek}" class="schedule-day-of-week" readonly>
                                 </td>
                                 <td>
-                                    <input type="time" th:value="${schedule.startTime}">
+                                    <input type="time" th:value="${schedule.startTime}" step="300">
                                 </td>
                                 <td>
-                                    <input type="time" th:value="${schedule.endTime}">
+                                    <input type="time" th:value="${schedule.endTime}" step="300">
                                 </td>
                                 <td>
                                     <input type="text" th:value="${schedule.location}">


### PR DESCRIPTION
## Summary
- limit start and end time inputs to 5 minute increments

## Testing
- `mvnw -q test` *(fails: unable to fetch Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68594c8bef3c832a887dabe6a3d15e80