### PR TITLE
Add 5 minute time selection

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -13,4 +13,28 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     });
+
+    const list = document.getElementById('time-5min');
+    if (list) {
+        for (let h = 0; h < 24; h++) {
+            for (let m = 0; m < 60; m += 5) {
+                const option = document.createElement('option');
+                option.value = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+                list.appendChild(option);
+            }
+        }
+    }
+
+    document.querySelectorAll('input[type="time"]').forEach(inp => {
+        inp.addEventListener('change', () => {
+            if (!inp.value) return;
+            let [h, m] = inp.value.split(':').map(Number);
+            m = Math.round(m / 5) * 5;
+            if (m === 60) {
+                m = 0;
+                h = (h + 1) % 24;
+            }
+            inp.value = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+        });
+    });
 });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -66,11 +66,11 @@
                                     <input type="text" th:value="${schedule.dayOfWeek}" class="schedule-day-of-week" readonly>
                                 </td>
                                 <td>
-                                     <input type="time" th:value="${schedule.startTime}" step="300">
-                                </td>
-                                <td>
-                                    <input type="time" th:value="${schedule.endTime}" step="300">
-                                </td>
+                                     <input type="time" th:value="${schedule.startTime}" step="300" list="time-5min">
+                                 </td>
+                                 <td>
+                                    <input type="time" th:value="${schedule.endTime}" step="300" list="time-5min">
+                                 </td>
                                 <td>
                                     <input type="text" th:value="${schedule.location}">
                                 </td>
@@ -83,6 +83,7 @@
         <script th:src="@{/js/calende.js}"></script>
         <script th:src="@{/js/tasks.js}"></script>
         <script th:src="@{/js/schedule.js}"></script>
-		
+        <datalist id="time-5min"></datalist>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure schedule time inputs increment by 5 minutes
- generate 5 minute options via datalist
- round entered times to nearest 5 minutes

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594e6b0930832a83560f57e67f50ef