### PR TITLE
Improve schedule time inputs

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -14,27 +14,33 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    const list = document.getElementById('time-5min');
-    if (list) {
+    function initTimeSelects(hourSel, minuteSel, time) {
         for (let h = 0; h < 24; h++) {
-            for (let m = 0; m < 60; m += 5) {
-                const option = document.createElement('option');
-                option.value = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-                list.appendChild(option);
-            }
+            const opt = document.createElement('option');
+            opt.value = String(h).padStart(2, '0');
+            opt.textContent = opt.value;
+            hourSel.appendChild(opt);
+        }
+        for (let m = 0; m < 60; m += 5) {
+            const opt = document.createElement('option');
+            opt.value = String(m).padStart(2, '0');
+            opt.textContent = opt.value;
+            minuteSel.appendChild(opt);
+        }
+        if (time) {
+            const [h, m] = time.split(':');
+            hourSel.value = h;
+            minuteSel.value = m.padStart(2, '0');
         }
     }
 
-    document.querySelectorAll('input[type="time"]').forEach(inp => {
-        inp.addEventListener('change', () => {
-            if (!inp.value) return;
-            let [h, m] = inp.value.split(':').map(Number);
-            m = Math.round(m / 5) * 5;
-            if (m === 60) {
-                m = 0;
-                h = (h + 1) % 24;
-            }
-            inp.value = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-        });
+    document.querySelectorAll('.start-hour').forEach(sel => {
+        const minuteSel = sel.parentElement.querySelector('.start-minute');
+        initTimeSelects(sel, minuteSel, sel.dataset.time);
+    });
+
+    document.querySelectorAll('.end-hour').forEach(sel => {
+        const minuteSel = sel.parentElement.querySelector('.end-minute');
+        initTimeSelects(sel, minuteSel, sel.dataset.time);
     });
 });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -66,11 +66,13 @@
                                     <input type="text" th:value="${schedule.dayOfWeek}" class="schedule-day-of-week" readonly>
                                 </td>
                                 <td>
-                                     <input type="time" th:value="${schedule.startTime}" step="300" list="time-5min">
-                                 </td>
-                                 <td>
-                                    <input type="time" th:value="${schedule.endTime}" step="300" list="time-5min">
-                                 </td>
+                                    <select class="start-hour" th:data-time="${schedule.startTime}"></select> :
+                                    <select class="start-minute" th:data-time="${schedule.startTime}"></select>
+                                </td>
+                                <td>
+                                    <select class="end-hour" th:data-time="${schedule.endTime}"></select> :
+                                    <select class="end-minute" th:data-time="${schedule.endTime}"></select>
+                                </td>
                                 <td>
                                     <input type="text" th:value="${schedule.location}">
                                 </td>
@@ -83,7 +85,6 @@
         <script th:src="@{/js/calende.js}"></script>
         <script th:src="@{/js/tasks.js}"></script>
         <script th:src="@{/js/schedule.js}"></script>
-        <datalist id="time-5min"></datalist>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- switch schedule time inputs to hour/minute select dropdowns
- support new inputs via JavaScript helper

## Testing
- `./mvnw -q test` *(fails: Failed to fetch ...)*

------
https://chatgpt.com/codex/tasks/task_e_68594fc95f6c832a95346e0467594bc7