### PR TITLE
Display schedule start countdown

### DIFF
--- a/src/main/java/com/example/demo/entity/Schedule.java
+++ b/src/main/java/com/example/demo/entity/Schedule.java
@@ -17,4 +17,5 @@ public class Schedule {
     private String detail;           // 詳細
     private int point;               // ポイント
     private LocalDate completedDay;  // 完了日（null 可）
+    private String timeUntilStart;   // 開始時刻までを表す文字列
 }

--- a/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
@@ -1,5 +1,8 @@
 package com.example.demo.service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -17,6 +20,17 @@ public class ScheduleServiceImpl implements ScheduleService {
 
     @Override
     public List<Schedule> getAllSchedules() {
-        return repository.findAll();
+        List<Schedule> list = repository.findAll();
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        for (Schedule s : list) {
+            LocalDateTime start = LocalDateTime.of(s.getScheduleDate(), s.getStartTime());
+            long minutes = Duration.between(now, start).toMinutes();
+            if (minutes < 0) minutes = 0;
+            long rounded = (minutes / 5) * 5;
+            long hours = rounded / 60;
+            long mins = rounded % 60;
+            s.setTimeUntilStart(String.format("%d時間%d分", hours, mins));
+        }
+        return list;
     }
 }

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -81,6 +81,19 @@
                                 <td>
                                     <input type="text" th:value="${schedule.location}">
                                 </td>
+                                <td>
+                                    <input type="text" th:value="${schedule.detail}">
+                                </td>
+                                <td></td>
+                                <td>
+                                    <input type="number" th:value="${schedule.point}">
+                                </td>
+                                <td>
+                                    <input type="date" th:value="${schedule.completedDay}">
+                                </td>
+                                <td>
+                                    <span th:text="${schedule.timeUntilStart}"></span>
+                                </td>
                         </tr>
                 </table>
         </div>


### PR DESCRIPTION
## Summary
- compute the remaining time until each schedule starts
- show the countdown in the schedule list

## Testing
- `./mvnw -q test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859534c467c832ab40231829511a87f