### PR TITLE
Fix schedule table whitespace

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -69,9 +69,9 @@ input.comment {
 
 table {
 	border: 1px solid #5e696c;
-	margin-left: auto;
-	margin-right: auto;
-	width: 80%; 					/* テーブル横幅 */
+	margin-left: 0;
+	margin-right: 0;
+	width: 100%; 					/* テーブル横幅 */
 	border-collapse:  collapse; 	/* 境界線を共有 */
 }
 
@@ -193,4 +193,11 @@ td {
     border: none;
     font-size: 16px;
     cursor: pointer;
+}
+
+body.task-body {
+    display: block;
+    height: auto;
+    justify-content: flex-start;
+    align-items: flex-start;
 }

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -6,7 +6,7 @@
 <title>トップ画面</title>
 <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
-<body>
+<body class="task-body">
         <div class="link-area">
                 <a href="challenge-box.html">挑戦ボックス</a>
                 <a href="question-survey-box.html">疑問・調査ボックス</a>


### PR DESCRIPTION
## Summary
- adjust table style for schedule list
- override body layout for task-top page

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685958d991fc832aa0f40d41ed35c99f