### PR TITLE
Adjust width of columns

### DIFF
--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -68,7 +68,7 @@
                                     <input type="date" th:value="${schedule.scheduleDate}" class="schedule-date-input">
                                 </td>
                                 <td>
-                                    <input type="text" th:value="${schedule.dayOfWeek}" class="schedule-day-of-week" readonly>
+                                    <input type="text" th:value="${schedule.dayOfWeek}" class="schedule-day-of-week" readonly size="2">
                                 </td>
                                 <td>
                                     <select class="start-hour" th:data-time="${schedule.startTime}"></select> :
@@ -79,7 +79,7 @@
                                     <select class="end-minute" th:data-time="${schedule.endTime}"></select>
                                 </td>
                                 <td>
-                                    <input type="text" th:value="${schedule.location}">
+                                    <input type="text" th:value="${schedule.location}" size="5">
                                 </td>
                                 <td>
                                     <input type="text" th:value="${schedule.detail}">
@@ -88,7 +88,7 @@
                                     <input type="text" th:value="${schedule.feedback}">
                                 </td>
                                 <td>
-                                    <input type="number" th:value="${schedule.point}">
+                                    <input type="number" th:value="${schedule.point}" size="2">
                                 </td>
                                 <td>
                                     <input type="date" th:value="${schedule.completedDay}">


### PR DESCRIPTION
## Summary
- update schedule table to limit input widths for day of week, location, and point columns

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595b67fb34832a899c979940ec78c3