### PR TITLE
Fix table width and disable wrapping

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -71,7 +71,7 @@ table {
 	border: 1px solid #5e696c;
 	margin-left: 0;
 	margin-right: 0;
-	width: 100%; 					/* テーブル横幅 */
+	width: auto; 					/* テーブル横幅 */
 	border-collapse:  collapse; 	/* 境界線を共有 */
 }
 
@@ -80,12 +80,14 @@ th {
     text-align:center;
     background-color: #3cb371;
     height: 32px;
+    white-space: nowrap;                /* 折り返さない */
 }
 
 td {
 	border: 1px solid #5e696c;
 	text-align: center;
 	height: 24px;
+    white-space: nowrap;                /* 折り返さない */
 }
 
 .restaurant-list {
@@ -167,6 +169,7 @@ td {
     border: 1px solid #5e696c;
     width: 40px;
     height: 32px;
+    white-space: nowrap;                /* 折り返さない */
     text-align: center;
     vertical-align: top;
 }


### PR DESCRIPTION
## Summary
- make table width auto instead of 100%
- prevent wrapping in table header and cells

## Testing
- `./mvnw -q test` *(fails: network access needed to download maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68595d241a94832a98974dd99a9e6ac2