### PR TITLE
Enable editing schedule fields

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import com.example.demo.form.TaskNameUpdate;
+import com.example.demo.form.ScheduleUpdateForm;
 
 import com.example.demo.entity.Task;
 import com.example.demo.entity.Schedule;
@@ -50,6 +51,12 @@ public class TaskListController {
     @PostMapping("/schedule-complete")
     public ResponseEntity<Void> updateCompletedDay(@RequestBody Schedule schedule) {
         scheduleService.updateCompletedDay(schedule);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/schedule-update")
+    public ResponseEntity<Void> updateSchedule(@RequestBody ScheduleUpdateForm form) {
+        scheduleService.updateSchedule(form);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/demo/form/ScheduleUpdateForm.java
+++ b/src/main/java/com/example/demo/form/ScheduleUpdateForm.java
@@ -1,0 +1,24 @@
+package com.example.demo.form;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import lombok.Data;
+
+@Data
+public class ScheduleUpdateForm {
+    private String oldTitle;
+    private LocalDate oldScheduleDate;
+
+    private boolean addFlag;
+    private String title;
+    private String dayOfWeek;
+    private LocalDate scheduleDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String location;
+    private String detail;
+    private String feedback;
+    private int point;
+    private LocalDate completedDay;
+}

--- a/src/main/java/com/example/demo/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepository.java
@@ -3,9 +3,12 @@ package com.example.demo.repository;
 import java.util.List;
 
 import com.example.demo.entity.Schedule;
+import com.example.demo.form.ScheduleUpdateForm;
 
 public interface ScheduleRepository {
     List<Schedule> findAll();
 
     void updateCompletedDay(Schedule schedule);
+
+    void updateSchedule(ScheduleUpdateForm form);
 }

--- a/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 import com.example.demo.entity.Schedule;
+import com.example.demo.form.ScheduleUpdateForm;
 
 import lombok.RequiredArgsConstructor;
 
@@ -54,5 +55,28 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
         String sql = "UPDATE schedules SET completed_day = ? WHERE title = ? AND schedule_date = ?";
         java.sql.Date day = schedule.getCompletedDay() != null ? java.sql.Date.valueOf(schedule.getCompletedDay()) : null;
         jdbcTemplate.update(sql, day, schedule.getTitle(), java.sql.Date.valueOf(schedule.getScheduleDate()));
+    }
+
+    @Override
+    public void updateSchedule(ScheduleUpdateForm form) {
+        String sql = "UPDATE schedules SET add_flag = ?, title = ?, day_of_week = ?, schedule_date = ?, start_time = ?, end_time = ?, location = ?, detail = ?, feedback = ?, point = ?, completed_day = ? WHERE title = ? AND schedule_date = ?";
+        java.sql.Date schedDate = java.sql.Date.valueOf(form.getScheduleDate());
+        java.sql.Time start = java.sql.Time.valueOf(form.getStartTime());
+        java.sql.Time end = java.sql.Time.valueOf(form.getEndTime());
+        java.sql.Date completed = form.getCompletedDay() != null ? java.sql.Date.valueOf(form.getCompletedDay()) : null;
+        jdbcTemplate.update(sql,
+                form.isAddFlag(),
+                form.getTitle(),
+                form.getDayOfWeek(),
+                schedDate,
+                start,
+                end,
+                form.getLocation(),
+                form.getDetail(),
+                form.getFeedback(),
+                form.getPoint(),
+                completed,
+                form.getOldTitle(),
+                java.sql.Date.valueOf(form.getOldScheduleDate()));
     }
 }

--- a/src/main/java/com/example/demo/service/ScheduleService.java
+++ b/src/main/java/com/example/demo/service/ScheduleService.java
@@ -3,9 +3,12 @@ package com.example.demo.service;
 import java.util.List;
 
 import com.example.demo.entity.Schedule;
+import com.example.demo.form.ScheduleUpdateForm;
 
 public interface ScheduleService {
     List<Schedule> getAllSchedules();
 
     void updateCompletedDay(Schedule schedule);
+
+    void updateSchedule(ScheduleUpdateForm form);
 }

--- a/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.example.demo.entity.Schedule;
+import com.example.demo.form.ScheduleUpdateForm;
 import com.example.demo.repository.ScheduleRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -40,5 +41,10 @@ public class ScheduleServiceImpl implements ScheduleService {
     @Override
     public void updateCompletedDay(Schedule schedule) {
         repository.updateCompletedDay(schedule);
+    }
+
+    @Override
+    public void updateSchedule(ScheduleUpdateForm form) {
+        repository.updateSchedule(form);
     }
 }

--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -1,4 +1,32 @@
 document.addEventListener('DOMContentLoaded', () => {
+    function sendUpdate(row) {
+        const data = {
+            oldTitle: row.dataset.oldTitle,
+            oldScheduleDate: row.dataset.oldDate,
+            addFlag: row.querySelector('.schedule-add-flag').checked,
+            title: row.querySelector('.schedule-title-input').value,
+            dayOfWeek: row.querySelector('.schedule-day-of-week').value,
+            scheduleDate: row.querySelector('.schedule-date-input').value,
+            startTime: row.querySelector('.start-hour').value.padStart(2, '0') + ':' +
+                       row.querySelector('.start-minute').value.padStart(2, '0'),
+            endTime: row.querySelector('.end-hour').value.padStart(2, '0') + ':' +
+                     row.querySelector('.end-minute').value.padStart(2, '0'),
+            location: row.querySelector('.schedule-location-input').value,
+            detail: row.querySelector('.schedule-detail-input').value,
+            feedback: row.querySelector('.schedule-feedback-input').value,
+            point: row.querySelector('.point-input').value,
+            completedDay: row.querySelector('.completed-day-input').value || null
+        };
+        fetch('/schedule-update', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+        }).then(() => {
+            row.dataset.oldTitle = data.title;
+            row.dataset.oldDate = data.scheduleDate;
+        });
+    }
+
     document.querySelectorAll('.schedule-date-input').forEach(inp => {
         inp.addEventListener('change', () => {
             const date = new Date(inp.value);
@@ -10,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (dayField) {
                     dayField.value = dow;
                 }
+                sendUpdate(row);
             }
         });
     });
@@ -37,11 +66,80 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.start-hour').forEach(sel => {
         const minuteSel = sel.parentElement.querySelector('.start-minute');
         initTimeSelects(sel, minuteSel, sel.dataset.time);
+        sel.addEventListener('change', () => {
+            const row = sel.closest('tr');
+            if (row) sendUpdate(row);
+        });
+        if (minuteSel) {
+            minuteSel.addEventListener('change', () => {
+                const row = sel.closest('tr');
+                if (row) sendUpdate(row);
+            });
+        }
     });
 
     document.querySelectorAll('.end-hour').forEach(sel => {
         const minuteSel = sel.parentElement.querySelector('.end-minute');
         initTimeSelects(sel, minuteSel, sel.dataset.time);
+        sel.addEventListener('change', () => {
+            const row = sel.closest('tr');
+            if (row) sendUpdate(row);
+        });
+        if (minuteSel) {
+            minuteSel.addEventListener('change', () => {
+                const row = sel.closest('tr');
+                if (row) sendUpdate(row);
+            });
+        }
+    });
+
+    document.querySelectorAll('.schedule-add-flag').forEach(cb => {
+        cb.addEventListener('change', () => {
+            const row = cb.closest('tr');
+            if (row) sendUpdate(row);
+        });
+    });
+
+    document.querySelectorAll('.schedule-title-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const row = inp.closest('tr');
+            if (row) sendUpdate(row);
+        });
+    });
+
+    document.querySelectorAll('.schedule-location-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const row = inp.closest('tr');
+            if (row) sendUpdate(row);
+        });
+    });
+
+    document.querySelectorAll('.schedule-detail-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const row = inp.closest('tr');
+            if (row) sendUpdate(row);
+        });
+    });
+
+    document.querySelectorAll('.schedule-feedback-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const row = inp.closest('tr');
+            if (row) sendUpdate(row);
+        });
+    });
+
+    document.querySelectorAll('.point-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const row = inp.closest('tr');
+            if (row) sendUpdate(row);
+        });
+    });
+
+    document.querySelectorAll('.completed-day-input').forEach(inp => {
+        inp.addEventListener('change', () => {
+            const row = inp.closest('tr');
+            if (row) sendUpdate(row);
+        });
     });
 
     document.querySelectorAll('.complete-button').forEach(btn => {
@@ -52,37 +150,17 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         btn.addEventListener('click', () => {
-            if (!row) return;
-            const title = row.querySelector('.schedule-title-input');
-            const date = row.querySelector('.schedule-date-input');
-            if (!comp) return;
+            if (!row || !comp) return;
 
             if (btn.value === '完了') {
                 const today = new Date().toISOString().split('T')[0];
                 comp.value = today;
                 btn.value = '取消';
-                fetch('/schedule-complete', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        title: title ? title.value : '',
-                        scheduleDate: date ? date.value : '',
-                        completedDay: today
-                    })
-                });
             } else {
                 comp.value = '';
                 btn.value = '完了';
-                fetch('/schedule-complete', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        title: title ? title.value : '',
-                        scheduleDate: date ? date.value : '',
-                        completedDay: null
-                    })
-                });
             }
+            sendUpdate(row);
         });
     });
 });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -54,12 +54,13 @@
 								<th>完了日</th>
 								<th>開始まで</th>
                         </tr>
-                        <tr th:each="schedule : ${schedules}">
+                        <tr th:each="schedule : ${schedules}" class="schedule-row"
+                            th:data-old-title="${schedule.title}" th:data-old-date="${schedule.scheduleDate}">
                                 <td>
                                     <input type="button" value="完了" class="complete-button">
                                 </td>
                                 <td>
-                                    <input type="checkbox" th:checked="${schedule.addFlag}" >
+                                    <input type="checkbox" th:checked="${schedule.addFlag}" class="schedule-add-flag">
                                 </td>
                                 <td>
                                     <input type="text" th:value="${schedule.title}" size="8" class="schedule-title-input">
@@ -79,13 +80,13 @@
                                     <select class="end-minute" th:data-time="${schedule.endTime}"></select>
                                 </td>
                                 <td>
-                                    <input type="text" th:value="${schedule.location}" size="5">
+                                    <input type="text" th:value="${schedule.location}" size="5" class="schedule-location-input">
                                 </td>
                                 <td>
-                                    <input type="text" th:value="${schedule.detail}" size="8">
+                                    <input type="text" th:value="${schedule.detail}" size="8" class="schedule-detail-input">
                                 </td>
-								<td>
-                                    <input type="text" th:value="${schedule.feedback}" size="8">
+                                                                <td>
+                                    <input type="text" th:value="${schedule.feedback}" size="8" class="schedule-feedback-input">
                                 </td>
                                 <td>
                                     <input type="number" th:value="${schedule.point}" size="2" class="point-input">


### PR DESCRIPTION
## Summary
- add `ScheduleUpdateForm` to hold old and new schedule values
- support updating schedule rows in repository, service and controller
- enhance schedule table markup with data attributes and classes
- update client JavaScript to send all schedule changes via `/schedule-update`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6859640b0f5c832a9b3f10b423c91aa1