### PR TITLE
Limit calendar text display

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -181,6 +181,10 @@ td {
 
 .calendar-area td .tasks div {
     font-size: 10px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 4ch;
 }
 
 /* 本日の日付を赤枠で強調 */

--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -67,7 +67,8 @@ document.addEventListener('DOMContentLoaded', () => {
             cell.appendChild(wrapper);
         }
         const item = document.createElement('div');
-        item.textContent = name;
+        item.textContent = name.slice(0, 4);
+        item.title = name;
         item.dataset.name = name;
         item.dataset.date = dateStr;
         wrapper.appendChild(item);

--- a/src/main/resources/static/js/tasks.js
+++ b/src/main/resources/static/js/tasks.js
@@ -49,7 +49,8 @@ document.addEventListener('DOMContentLoaded', () => {
             cell.appendChild(wrapper);
         }
         const item = document.createElement('div');
-        item.textContent = name;
+        item.textContent = name.slice(0, 4);
+        item.title = name;
         item.dataset.name = name;
         wrapper.appendChild(item);
     }


### PR DESCRIPTION
## Summary
- truncate event text when rendering schedule/tasks
- ensure calendar items don't wrap and have consistent width

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685968f49a68832aa575124940742f9d