### PR TITLE
Add daily schedule popup to calendar

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -213,3 +213,40 @@ body.task-body {
     justify-content: flex-start;
     align-items: flex-start;
 }
+
+/* overlay for daily schedule detail */
+.schedule-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 999;
+}
+
+.schedule-popup {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #fff;
+    border: 2px solid #5e696c;
+    padding: 10px;
+    border-radius: 8px;
+    z-index: 1000;
+    min-width: 200px;
+}
+
+.schedule-popup button {
+    float: right;
+    cursor: pointer;
+}
+
+.schedule-popup ul {
+    list-style: none;
+    padding-left: 0;
+    margin-top: 10px;
+}

--- a/src/main/resources/static/js/calendar-detail.js
+++ b/src/main/resources/static/js/calendar-detail.js
@@ -1,0 +1,82 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const overlay = document.getElementById('schedule-overlay');
+    const popup = document.getElementById('schedule-popup');
+    const closeBtn = document.getElementById('close-schedule-popup');
+    const listEl = document.getElementById('schedule-popup-list');
+    const titleEl = document.getElementById('schedule-popup-title');
+
+    function getYearMonth() {
+        const title = document.getElementById('calendar-title');
+        if (title) {
+            const m = title.textContent.match(/(\d+)年(\d+)月/);
+            if (m) {
+                return { year: parseInt(m[1], 10), month: parseInt(m[2], 10) };
+            }
+        }
+        const now = new Date();
+        return { year: now.getFullYear(), month: now.getMonth() + 1 };
+    }
+
+    function hide() {
+        overlay.style.display = 'none';
+        popup.style.display = 'none';
+    }
+
+    function show(dateStr) {
+        listEl.innerHTML = '';
+        const rows = document.querySelectorAll('.schedule-row');
+        let items = [];
+        rows.forEach(row => {
+            const addFlag = row.querySelector('.schedule-add-flag');
+            if (!addFlag || !addFlag.checked) return;
+            const schedDate = row.querySelector('.schedule-date-input').value;
+            if (schedDate !== dateStr) return;
+            const title = row.querySelector('.schedule-title-input').value;
+            const start =
+                row.querySelector('.start-hour').value.padStart(2, '0') + ':' +
+                row.querySelector('.start-minute').value.padStart(2, '0');
+            const end =
+                row.querySelector('.end-hour').value.padStart(2, '0') + ':' +
+                row.querySelector('.end-minute').value.padStart(2, '0');
+            items.push({ start, end, title });
+        });
+        items.sort((a, b) => a.start.localeCompare(b.start));
+        if (items.length === 0) {
+            const li = document.createElement('li');
+            li.textContent = '予定はありません';
+            listEl.appendChild(li);
+        } else {
+            items.forEach(it => {
+                const li = document.createElement('li');
+                li.textContent = `${it.start} - ${it.end} ${it.title}`;
+                listEl.appendChild(li);
+            });
+        }
+        titleEl.textContent = dateStr;
+        overlay.style.display = 'block';
+        popup.style.display = 'block';
+    }
+
+    closeBtn.addEventListener('click', hide);
+    overlay.addEventListener('click', hide);
+
+    function attach() {
+        const table = document.getElementById('calendar');
+        if (!table) return;
+        table.addEventListener('click', (e) => {
+            const td = e.target.closest('td');
+            if (!td || !td.parentElement) return;
+            const day = parseInt(td.textContent, 10);
+            if (isNaN(day)) return;
+            const { year, month } = getYearMonth();
+            const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+            show(dateStr);
+        });
+    }
+
+    attach();
+    document.addEventListener('calendarRendered', () => {
+        // no need to reattach since using event delegation
+    });
+});
+

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -103,9 +103,17 @@
 		
 		
 
+        <div id="schedule-overlay" class="schedule-overlay"></div>
+        <div id="schedule-popup" class="schedule-popup">
+            <button id="close-schedule-popup">&#x2715;</button>
+            <h3 id="schedule-popup-title"></h3>
+            <ul id="schedule-popup-list"></ul>
+        </div>
+
         <script th:src="@{/js/calende.js}"></script>
         <script th:src="@{/js/tasks.js}"></script>
         <script th:src="@{/js/schedule.js}"></script>
+        <script th:src="@{/js/calendar-detail.js}"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style popup overlay for daily schedule info
- add popup container to `task-top.html`
- implement `calendar-detail.js` to show schedules when calendar dates are clicked

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596b5d8b10832aa2a8e67b1537e272