### PR TITLE
Add schedule creation feature

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -59,4 +59,10 @@ public class TaskListController {
         scheduleService.updateSchedule(form);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/schedule-add")
+    public ResponseEntity<Void> addSchedule(@RequestBody Schedule schedule) {
+        scheduleService.addSchedule(schedule);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/demo/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepository.java
@@ -11,4 +11,6 @@ public interface ScheduleRepository {
     void updateCompletedDay(Schedule schedule);
 
     void updateSchedule(ScheduleUpdateForm form);
+
+    void insertSchedule(Schedule schedule);
 }

--- a/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
@@ -79,4 +79,25 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
                 form.getOldTitle(),
                 java.sql.Date.valueOf(form.getOldScheduleDate()));
     }
+
+    @Override
+    public void insertSchedule(Schedule schedule) {
+        String sql = "INSERT INTO schedules (add_flag, title, day_of_week, schedule_date, start_time, end_time, location, detail, feedback, point, completed_day) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        java.sql.Date schedDate = java.sql.Date.valueOf(schedule.getScheduleDate());
+        java.sql.Time start = java.sql.Time.valueOf(schedule.getStartTime());
+        java.sql.Time end = java.sql.Time.valueOf(schedule.getEndTime());
+        java.sql.Date completed = schedule.getCompletedDay() != null ? java.sql.Date.valueOf(schedule.getCompletedDay()) : null;
+        jdbcTemplate.update(sql,
+                schedule.isAddFlag(),
+                schedule.getTitle(),
+                schedule.getDayOfWeek(),
+                schedDate,
+                start,
+                end,
+                schedule.getLocation(),
+                schedule.getDetail(),
+                schedule.getFeedback(),
+                schedule.getPoint(),
+                completed);
+    }
 }

--- a/src/main/java/com/example/demo/service/ScheduleService.java
+++ b/src/main/java/com/example/demo/service/ScheduleService.java
@@ -11,4 +11,6 @@ public interface ScheduleService {
     void updateCompletedDay(Schedule schedule);
 
     void updateSchedule(ScheduleUpdateForm form);
+
+    void addSchedule(Schedule schedule);
 }

--- a/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
@@ -47,4 +47,9 @@ public class ScheduleServiceImpl implements ScheduleService {
     public void updateSchedule(ScheduleUpdateForm form) {
         repository.updateSchedule(form);
     }
+
+    @Override
+    public void addSchedule(Schedule schedule) {
+        repository.insertSchedule(schedule);
+    }
 }

--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -258,6 +258,35 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    const newButton = document.getElementById('new-schedule-button');
+    if (newButton) {
+        newButton.addEventListener('click', () => {
+            const today = new Date();
+            const dateStr = today.toISOString().split('T')[0];
+            const dow = today.toLocaleDateString('ja-JP', { weekday: 'short' });
+            const data = {
+                addFlag: false,
+                title: '',
+                dayOfWeek: dow,
+                scheduleDate: dateStr,
+                startTime: '00:00',
+                endTime: '01:00',
+                location: '',
+                detail: '',
+                feedback: '',
+                point: 0,
+                completedDay: null
+            };
+            fetch('/schedule-add', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            }).then(() => {
+                location.reload();
+            });
+        });
+    }
+
     initSchedules();
     document.addEventListener('calendarRendered', initSchedules);
 });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -100,6 +100,7 @@
                         </tr>
                 </table>
         </div>
+        <button id="new-schedule-button">新規</button>
 		
 		
 


### PR DESCRIPTION
## Summary
- implement `insertSchedule` in repository and service layers
- expose `/schedule-add` endpoint for creating schedules
- add '新規' button on task-top page and client-side handler

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596d36fd24832a8af4aeea2e677e15