### PR TITLE
Enable schedule deletion via ID

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -74,4 +74,11 @@ public class TaskListController {
         scheduleService.addSchedule(schedule);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/schedule-delete")
+    public ResponseEntity<Void> deleteSchedule(@RequestBody Schedule schedule) {
+        log.debug("Deleting schedule id {}", schedule.getId());
+        scheduleService.deleteScheduleById(schedule.getId());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/demo/entity/Schedule.java
+++ b/src/main/java/com/example/demo/entity/Schedule.java
@@ -7,6 +7,7 @@ import lombok.Data;
 
 @Data
 public class Schedule {
+    private int id;                  // ID
     private boolean addFlag;         // 予定追加 ON/OFF
     private String title;            // 予定名
     private String dayOfWeek;        // 曜日

--- a/src/main/java/com/example/demo/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepository.java
@@ -13,4 +13,6 @@ public interface ScheduleRepository {
     void updateSchedule(ScheduleUpdateForm form);
 
     void insertSchedule(Schedule schedule);
+
+    void deleteById(int id);
 }

--- a/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
@@ -23,11 +23,12 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
 
     @Override
     public List<Schedule> findAll() {
-        String sql = "SELECT add_flag, title, day_of_week, schedule_date, start_time, end_time, location, detail, feedback,point, completed_day FROM schedules";
+        String sql = "SELECT id, add_flag, title, day_of_week, schedule_date, start_time, end_time, location, detail, feedback, point, completed_day FROM schedules";
         return jdbcTemplate.query(sql, new RowMapper<Schedule>() {
             @Override
             public Schedule mapRow(ResultSet rs, int rowNum) throws SQLException {
                 Schedule s = new Schedule();
+                s.setId(rs.getInt("id"));
                 s.setAddFlag(rs.getBoolean("add_flag"));
                 s.setTitle(rs.getString("title"));
                 s.setDayOfWeek(rs.getString("day_of_week"));
@@ -99,5 +100,11 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
                 schedule.getFeedback(),
                 schedule.getPoint(),
                 completed);
+    }
+
+    @Override
+    public void deleteById(int id) {
+        String sql = "DELETE FROM schedules WHERE id = ?";
+        jdbcTemplate.update(sql, id);
     }
 }

--- a/src/main/java/com/example/demo/service/ScheduleService.java
+++ b/src/main/java/com/example/demo/service/ScheduleService.java
@@ -13,4 +13,6 @@ public interface ScheduleService {
     void updateSchedule(ScheduleUpdateForm form);
 
     void addSchedule(Schedule schedule);
+
+    void deleteScheduleById(int id);
 }

--- a/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
@@ -58,4 +58,10 @@ public class ScheduleServiceImpl implements ScheduleService {
         log.debug("Adding schedule {} on {}", schedule.getTitle(), schedule.getScheduleDate());
         repository.insertSchedule(schedule);
     }
+
+    @Override
+    public void deleteScheduleById(int id) {
+        log.debug("Deleting schedule with id {}", id);
+        repository.deleteById(id);
+    }
 }

--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -276,6 +276,22 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    document.querySelectorAll('.delete-button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const row = btn.closest('tr');
+            if (!row) return;
+            const id = row.dataset.id;
+            if (!id) return;
+            fetch('/schedule-delete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ id: parseInt(id, 10) })
+            }).then(() => {
+                location.reload();
+            });
+        });
+    });
+
     const newButton = document.getElementById('new-schedule-button');
     if (newButton) {
         newButton.addEventListener('click', () => {

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -56,7 +56,7 @@
 								<th>開始まで</th>
                         </tr>
                         <tr th:each="schedule : ${schedules}" class="schedule-row"
-                            th:data-old-title="${schedule.title}" th:data-old-date="${schedule.scheduleDate}">
+                            th:data-id="${schedule.id}" th:data-old-title="${schedule.title}" th:data-old-date="${schedule.scheduleDate}">
                                 <td>
                                     <input type="button" value="完了" class="complete-button">
                                 </td>


### PR DESCRIPTION
## Summary
- add `id` field to `Schedule` entity
- allow deleting schedules by id via new repository/service/controller methods
- render schedule id in the page markup and handle delete button clicks in JavaScript

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685a95e986ac832a947c79e974690eaa