### PR TITLE
Update schedule update by id

### DIFF
--- a/src/main/java/com/example/demo/form/ScheduleUpdateForm.java
+++ b/src/main/java/com/example/demo/form/ScheduleUpdateForm.java
@@ -7,6 +7,7 @@ import lombok.Data;
 
 @Data
 public class ScheduleUpdateForm {
+    private int id;
     private String oldTitle;
     private LocalDate oldScheduleDate;
 

--- a/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
@@ -60,7 +60,7 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
 
     @Override
     public void updateSchedule(ScheduleUpdateForm form) {
-        String sql = "UPDATE schedules SET add_flag = ?, title = ?, day_of_week = ?, schedule_date = ?, start_time = ?, end_time = ?, location = ?, detail = ?, feedback = ?, point = ?, completed_day = ? WHERE title = ? AND schedule_date = ?";
+        String sql = "UPDATE schedules SET add_flag = ?, title = ?, day_of_week = ?, schedule_date = ?, start_time = ?, end_time = ?, location = ?, detail = ?, feedback = ?, point = ?, completed_day = ? WHERE id = ?";
         java.sql.Date schedDate = java.sql.Date.valueOf(form.getScheduleDate());
         java.sql.Time start = java.sql.Time.valueOf(form.getStartTime());
         java.sql.Time end = java.sql.Time.valueOf(form.getEndTime());
@@ -77,8 +77,7 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
                 form.getFeedback(),
                 form.getPoint(),
                 completed,
-                form.getOldTitle(),
-                java.sql.Date.valueOf(form.getOldScheduleDate()));
+                form.getId());
     }
 
     @Override

--- a/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
@@ -49,7 +49,7 @@ public class ScheduleServiceImpl implements ScheduleService {
 
     @Override
     public void updateSchedule(ScheduleUpdateForm form) {
-        log.debug("Updating schedule {} on {}", form.getTitle(), form.getScheduleDate());
+        log.debug("Updating schedule id {} - {} on {}", form.getId(), form.getTitle(), form.getScheduleDate());
         repository.updateSchedule(form);
     }
 

--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     function sendUpdate(row) {
         const data = {
+            id: parseInt(row.dataset.id, 10),
             oldTitle: row.dataset.oldTitle,
             oldScheduleDate: row.dataset.oldDate,
             addFlag: row.querySelector('.schedule-add-flag').checked,


### PR DESCRIPTION
## Summary
- add id field to `ScheduleUpdateForm`
- update SQL in `ScheduleRepositoryImpl` to update by `id`
- log schedule id during update
- send schedule id from `schedule.js` when updating

## Testing
- `sh ./mvnw -q test` *(fails: Could not resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_685a9d0d7c84832a8b6c613898410008