### PR TITLE
Fix duplicate schedule dates

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -148,7 +148,6 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         };
         inp.addEventListener('change', handler);
-        inp.addEventListener('input', handler);
     });
 
     function initTimeSelects(hourSel, minuteSel, time) {


### PR DESCRIPTION
## Summary
- remove `input` event handler from schedule date fields so calendar entries update only once per change

## Testing
- `mvn -q test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685aa9211138832a801865380d87ffdf