### PR TITLE
Update schedule time display automatically

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -53,6 +53,23 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function updateTimeUntilStart(row) {
+        const dateStr = row.querySelector('.schedule-date-input').value;
+        const hourSel = row.querySelector('.start-hour');
+        const minuteSel = row.querySelector('.start-minute');
+        if (!dateStr || !hourSel || !minuteSel) return;
+        const start = new Date(`${dateStr}T${hourSel.value.padStart(2,'0')}:${minuteSel.value.padStart(2,'0')}:00`);
+        const now = new Date();
+        let diff = Math.floor((start - now) / 60000); // minutes
+        if (diff < 0) diff = 0;
+        diff = Math.floor(diff / 5) * 5;
+        const days = Math.floor(diff / (60 * 24));
+        const hours = Math.floor((diff % (60 * 24)) / 60);
+        const mins = diff % 60;
+        const span = row.querySelector('td:last-child span');
+        if (span) span.textContent = `${days}日${hours}時間${mins}分`;
+    }
+
     const calendar = document.getElementById('calendar');
     let dayCells = {};
     let currentYear = new Date().getFullYear();
@@ -144,6 +161,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     addSchedule(row.querySelector('.schedule-title-input').value, inp.value);
                 }
                 sendUpdate(row);
+                updateTimeUntilStart(row);
                 sortScheduleTable();
             }
         };
@@ -177,6 +195,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const row = sel.closest('tr');
             if (row) {
                 sendUpdate(row);
+                updateTimeUntilStart(row);
                 sortScheduleTable();
             }
         });
@@ -185,6 +204,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const row = sel.closest('tr');
                 if (row) {
                     sendUpdate(row);
+                    updateTimeUntilStart(row);
                     sortScheduleTable();
                 }
             });


### PR DESCRIPTION
## Summary
- add `updateTimeUntilStart` helper in `schedule.js`
- refresh time remaining when schedule date or start time changes

## Testing
- `mvn test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685aac4ddb8c832aa241c573fdc098ce