### PR TITLE
Add link area and route for task box

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -33,6 +33,12 @@ public class TaskListController {
         return "task-top";
     }
 
+    @GetMapping("/task-box")
+    public String showTaskBox() {
+        log.debug("Displaying task box page");
+        return "task-box";
+    }
+
     @PostMapping("/task-confirm")
     public ResponseEntity<Void> updateConfirmed(@RequestBody Task task) {
         log.debug("Updating task confirm: {} {}", task.getTaskName(), task.isConfirmed());

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -133,13 +133,14 @@ td {
 
 /* リンクエリアを画面左上に配置 */
 .link-area {
-    position: absolute;
+    position: fixed;
     top: 10px;
     left: 10px;
     border: 2px solid #5e696c;
     padding: 10px;
     background-color: #fff;
     border-radius: 8px;
+    z-index: 1000;
 }
 
 .link-area a {
@@ -212,6 +213,7 @@ body.task-body {
     height: auto;
     justify-content: flex-start;
     align-items: flex-start;
+    margin-top: 80px; /* space for link and calendar */
 }
 
 /* overlay for daily schedule detail */

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -7,12 +7,12 @@
 <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body class="task-body">
-<!--        <div class="link-area">-->
-<!--                <a href="challenge-box.html">挑戦ボックス</a>-->
-<!--                <a href="question-survey-box.html">疑問・調査ボックス</a>-->
-<!--                <a href="task-box.html">タスクボックス</a>-->
-<!--        </div>-->
-		<div id="calendar" class="calendar-area"></div>
+        <div class="link-area">
+                <a href="challenge-box.html">挑戦ボックス</a>
+                <a href="question-survey-box.html">疑問・調査ボックス</a>
+                <a th:href="@{/task-box}">タスクボックス</a>
+        </div>
+                <div id="calendar" class="calendar-area"></div>
 
 <!--        <div>-->
 <!--                <table>-->


### PR DESCRIPTION
## Summary
- enable navigation links on `task-top.html`
- style the link area to stay fixed and keep content below
- add mapping for `/task-box` page

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685aafaea374832a8d618d4c7c882ad0