### PR TITLE
Display completed schedules on task box page

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -34,8 +34,12 @@ public class TaskListController {
     }
 
     @GetMapping("/task-box")
-    public String showTaskBox() {
+    public String showTaskBox(Model model) {
         log.debug("Displaying task box page");
+        var list = scheduleService.getAllSchedules().stream()
+                .filter(s -> s.getCompletedDay() != null)
+                .toList();
+        model.addAttribute("schedules", list);
         return "task-box";
     }
 

--- a/src/main/resources/templates/task-box.html
+++ b/src/main/resources/templates/task-box.html
@@ -1,12 +1,56 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
-<html>
 <head>
 <meta charset="UTF-8">
 <title>タスクボックス</title>
+<link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
-<body>
-	<p>非表示リスト</p>
-
+<body class="task-body">
+    <div id="calendar" style="display:none;"></div>
+    <div class="database-container">
+        <table class="database-table">
+            <tr>
+                <th>完了</th>
+                <th>削除</th>
+                <th>add</th>
+                <th>予定名</th>
+                <th>予定日</th>
+                <th>曜日</th>
+                <th>開始時刻</th>
+                <th>終了時刻</th>
+                <th>場所</th>
+                <th>詳細</th>
+                <th>feedback</th>
+                <th>point</th>
+                <th>完了日</th>
+                <th>開始まで</th>
+            </tr>
+            <tr th:each="schedule : ${schedules}" class="schedule-row"
+                th:data-id="${schedule.id}" th:data-old-title="${schedule.title}"
+                th:data-old-date="${schedule.scheduleDate}">
+                <td><input type="button" value="完了" class="complete-button"></td>
+                <td><input type="button" value="削除" class="delete-button"></td>
+                <td><input type="checkbox" th:checked="${schedule.addFlag}" class="schedule-add-flag"></td>
+                <td><input type="text" th:value="${schedule.title}" size="8" class="schedule-title-input"></td>
+                <td><input type="date" th:value="${schedule.scheduleDate}" class="schedule-date-input"></td>
+                <td><input type="text" th:value="${schedule.dayOfWeek}" class="schedule-day-of-week" readonly size="2"></td>
+                <td>
+                    <select class="start-hour" th:data-time="${schedule.startTime}"></select> :
+                    <select class="start-minute" th:data-time="${schedule.startTime}"></select>
+                </td>
+                <td>
+                    <select class="end-hour" th:data-time="${schedule.endTime}"></select> :
+                    <select class="end-minute" th:data-time="${schedule.endTime}"></select>
+                </td>
+                <td><input type="text" th:value="${schedule.location}" size="5" class="schedule-location-input"></td>
+                <td><input type="text" th:value="${schedule.detail}" size="8" class="schedule-detail-input"></td>
+                <td><input type="text" th:value="${schedule.feedback}" size="8" class="schedule-feedback-input"></td>
+                <td><input type="number" th:value="${schedule.point}" size="2" class="point-input"></td>
+                <td><input type="date" th:value="${schedule.completedDay}" class="completed-day-input"></td>
+                <td><span th:text="${schedule.timeUntilStart}"></span></td>
+            </tr>
+        </table>
+    </div>
+    <script th:src="@{/js/schedule.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- filter schedules with non-null completion dates in `TaskListController`
- show schedule database on `task-box.html` using same table layout as task top

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685ab87d48c0832a92baadc72ca42978