### PR TITLE
Filter completed schedules and hide row on completion

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -29,7 +29,10 @@ public class TaskListController {
     public String showTaskTop(Model model) {
         log.debug("Displaying task top page");
         model.addAttribute("tasks", service.getAllTasks());
-        model.addAttribute("schedules", scheduleService.getAllSchedules());
+        var list = scheduleService.getAllSchedules().stream()
+                .filter(s -> s.getCompletedDay() == null)
+                .toList();
+        model.addAttribute("schedules", list);
         return "task-top";
     }
 

--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -296,7 +296,17 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.completed-day-input').forEach(inp => {
         const handler = () => {
             const row = inp.closest('tr');
-            if (row) sendUpdate(row);
+            if (row) {
+                sendUpdate(row);
+                if (inp.value) {
+                    row.style.display = 'none';
+                    const span = row.querySelector('td:last-child span');
+                    if (span) span.textContent = '';
+                } else {
+                    row.style.display = '';
+                    updateTimeUntilStart(row);
+                }
+            }
         };
         inp.addEventListener('change', handler);
         inp.addEventListener('input', handler);
@@ -319,6 +329,14 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 comp.value = '';
                 btn.value = '完了';
+            }
+            const span = row.querySelector('td:last-child span');
+            if (comp.value) {
+                row.style.display = 'none';
+                if (span) span.textContent = '';
+            } else {
+                row.style.display = '';
+                updateTimeUntilStart(row);
             }
             sendUpdate(row);
         });


### PR DESCRIPTION
## Summary
- filter out completed schedules when rendering task-top
- immediately hide a schedule row in the browser once completion date is set

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685abad8a4a8832a832e078b2185ee34