### PR TITLE
Set timeUntilStart null for completed schedules

### DIFF
--- a/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
@@ -27,6 +27,12 @@ public class ScheduleServiceImpl implements ScheduleService {
         List<Schedule> list = repository.findAll();
         LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
         for (Schedule s : list) {
+            // When a schedule is completed, the remaining time should no longer be displayed
+            if (s.getCompletedDay() != null) {
+                s.setTimeUntilStart(null);
+                continue;
+            }
+
             LocalDateTime start = LocalDateTime.of(s.getScheduleDate(), s.getStartTime());
             long minutes = Duration.between(now, start).toMinutes();
             if (minutes < 0) minutes = 0;


### PR DESCRIPTION
## Summary
- ensure `timeUntilStart` is cleared for completed schedules

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685abfd5e6ac832a9fe43e100f2fbcdb