### PR TITLE
Fix upcoming schedule display in task-box

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -39,10 +39,15 @@ public class TaskListController {
     @GetMapping("/task-box")
     public String showTaskBox(Model model) {
         log.debug("Displaying task box page");
-        var list = scheduleService.getAllSchedules().stream()
+        var all = scheduleService.getAllSchedules();
+        var completed = all.stream()
                 .filter(s -> s.getCompletedDay() != null)
                 .toList();
-        model.addAttribute("schedules", list);
+        var upcoming = all.stream()
+                .filter(s -> s.getCompletedDay() == null)
+                .toList();
+        model.addAttribute("completedSchedules", completed);
+        model.addAttribute("upcomingSchedules", upcoming);
         return "task-box";
     }
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -101,6 +101,11 @@ td {
     margin-top: -50px;
 }
 
+/* ensure spacing when multiple tables are stacked */
+.database-container + .database-container {
+    margin-top: 40px;
+}
+
 .database-table {
     margin-left: 0;
 }

--- a/src/main/resources/templates/task-box.html
+++ b/src/main/resources/templates/task-box.html
@@ -15,7 +15,7 @@
 	
 	
     <div class="database-container">
-		<p>予定完了済み</p>
+                <p>予定完了済み</p>
         <table class="database-table">
             <tr>
                 <th>完了</th>
@@ -33,7 +33,7 @@
                 <th>完了日</th>
                 <th>開始まで</th>
             </tr>
-            <tr th:each="schedule : ${schedules}" class="schedule-row"
+            <tr th:each="schedule : ${completedSchedules}" class="schedule-row"
                 th:data-id="${schedule.id}" th:data-old-title="${schedule.title}"
                 th:data-old-date="${schedule.scheduleDate}">
                 <td><input type="button" value="完了" class="complete-button"></td>
@@ -61,8 +61,8 @@
     </div>
 	
 	
-	<div class="database-container">
-		<p>これからの予定</p>
+        <div class="database-container">
+                <p>これからの予定</p>
             <table class="database-table">
                     <tr>
                             <th>完了</th>
@@ -80,7 +80,7 @@
 							<th>完了日</th>
 							<th>開始まで</th>
                     </tr>
-                    <tr th:each="schedule : ${schedules}" class="schedule-row"
+                    <tr th:each="schedule : ${upcomingSchedules}" class="schedule-row"
                         th:data-id="${schedule.id}" th:data-old-title="${schedule.title}" th:data-old-date="${schedule.scheduleDate}">
                             <td>
                                 <input type="button" value="完了" class="complete-button">


### PR DESCRIPTION
## Summary
- show completed and upcoming schedules separately
- filter upcoming schedules for records without completion date
- prevent schedule tables from overlapping

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685ac2d44274832abe84d3b04083422e