### PR TITLE
Fix completion button on task-top.html

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -31,9 +31,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function moveRowBasedOnCompletion(row, completed) {
-        const target = completed ? completedTable : upcomingTable;
-        moveRow(row, target);
-        sortScheduleTable(target);
+        if (completedTable && upcomingTable) {
+            const target = completed ? completedTable : upcomingTable;
+            moveRow(row, target);
+            sortScheduleTable(target);
+        } else {
+            // When tables are not separated, simply hide or show the row
+            row.style.display = completed ? 'none' : '';
+        }
     }
 
     function sendUpdate(row) {


### PR DESCRIPTION
## Summary
- hide schedule rows when completed if task-top.html doesn't provide separate tables

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because the repo can't be reached)*

------
https://chatgpt.com/codex/tasks/task_e_685bc407e468832a948d188d8f884e9f