### PR TITLE
Update task top URL to include username

### DIFF
--- a/src/main/java/com/example/demo/controller/LoginController.java
+++ b/src/main/java/com/example/demo/controller/LoginController.java
@@ -45,18 +45,18 @@ public class LoginController {
 	
     @PostMapping("/task-top")
     public String showTop(LogInForm form, Model model) {
-            User u = new User();
-            u.setUsername(form.getUsername());
-            u.setPassword(form.getPassword());
-            log.debug("Attempting login for user: {}", form.getUsername());
-            if (loginService.login(u)) {
-                    log.debug("Login success for user: {}", form.getUsername());
-                    return "redirect:/task-top";
-            } else {
-                    log.debug("Login failed for user: {}", form.getUsername());
-                    model.addAttribute("errorMessage", "ログイン失敗");
-                    return "log-in";
-            }
+        User u = new User();
+        u.setUsername(form.getUsername());
+        u.setPassword(form.getPassword());
+        log.debug("Attempting login for user: {}", form.getUsername());
+        if (loginService.login(u)) {
+            log.debug("Login success for user: {}", form.getUsername());
+            return "redirect:/" + form.getUsername() + "/task-top";
+        } else {
+            log.debug("Login failed for user: {}", form.getUsername());
+            model.addAttribute("errorMessage", "ログイン失敗");
+            return "log-in";
+        }
     }
 }
 

--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -6,6 +6,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import com.example.demo.form.TaskNameUpdate;
 import com.example.demo.form.ScheduleUpdateForm;
 
@@ -25,19 +27,20 @@ public class TaskListController {
     private final TaskService service;
     private final ScheduleService scheduleService;
 
-    @GetMapping("/task-top")
-    public String showTaskTop(Model model) {
+    @GetMapping("/{username}/task-top")
+    public String showTaskTop(@PathVariable String username, Model model) {
         log.debug("Displaying task top page");
         model.addAttribute("tasks", service.getAllTasks());
         var list = scheduleService.getAllSchedules().stream()
                 .filter(s -> s.getCompletedDay() == null)
                 .toList();
         model.addAttribute("schedules", list);
+        model.addAttribute("username", username);
         return "task-top";
     }
 
     @GetMapping("/task-box")
-    public String showTaskBox(Model model) {
+    public String showTaskBox(@RequestParam(value = "username", required = false) String username, Model model) {
         log.debug("Displaying task box page");
         var all = scheduleService.getAllSchedules();
         var completed = all.stream()
@@ -48,6 +51,9 @@ public class TaskListController {
                 .toList();
         model.addAttribute("completedSchedules", completed);
         model.addAttribute("upcomingSchedules", upcoming);
+        if (username != null) {
+            model.addAttribute("username", username);
+        }
         return "task-box";
     }
 

--- a/src/main/resources/templates/task-box.html
+++ b/src/main/resources/templates/task-box.html
@@ -8,8 +8,8 @@
 <body class="task-body">
     <div id="calendar" style="display:none;"></div>
 	
-	<div class="link-area">
-            <a th:href="@{/task-top}">TOPへ</a>
+        <div class="link-area">
+            <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
     </div>
 	
 

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -10,7 +10,7 @@
         <div class="link-area">
                 <a href="challenge-box.html">挑戦ボックス</a>
                 <a href="question-survey-box.html">疑問・調査ボックス</a>
-                <a th:href="@{/task-box}">タスクボックス</a>
+                <a th:href="@{'/task-box?username=' + ${username}}">タスクボックス</a>
         </div>
                 <div id="calendar" class="calendar-area"></div>
 


### PR DESCRIPTION
## Summary
- change login success redirect to `/username/task-top`
- map task top page at `/{username}/task-top`
- propagate username when navigating to and from the task box page

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685bc85b18b0832a81c252e8c73d512f