### PR TITLE
Support nested task-box URL

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import com.example.demo.form.TaskNameUpdate;
 import com.example.demo.form.ScheduleUpdateForm;
 
@@ -39,8 +38,8 @@ public class TaskListController {
         return "task-top";
     }
 
-    @GetMapping("/task-box")
-    public String showTaskBox(@RequestParam(value = "username", required = false) String username, Model model) {
+    @GetMapping("/{username}/task-top/task-box")
+    public String showTaskBox(@PathVariable String username, Model model) {
         log.debug("Displaying task box page");
         var all = scheduleService.getAllSchedules();
         var completed = all.stream()
@@ -51,9 +50,7 @@ public class TaskListController {
                 .toList();
         model.addAttribute("completedSchedules", completed);
         model.addAttribute("upcomingSchedules", upcoming);
-        if (username != null) {
-            model.addAttribute("username", username);
-        }
+        model.addAttribute("username", username);
         return "task-box";
     }
 

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -10,7 +10,7 @@
         <div class="link-area">
                 <a href="challenge-box.html">挑戦ボックス</a>
                 <a href="question-survey-box.html">疑問・調査ボックス</a>
-                <a th:href="@{'/task-box?username=' + ${username}}">タスクボックス</a>
+                <a th:href="@{'/' + ${username} + '/task-top/task-box'}">タスクボックス</a>
         </div>
                 <div id="calendar" class="calendar-area"></div>
 


### PR DESCRIPTION
## Summary
- serve task box page with `/{username}/task-top/task-box` mapping
- update top page link to new URL pattern

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685bc9e6e2b4832ab39f855b96f4f437