### PR TITLE
Add session checks for task pages

### DIFF
--- a/src/main/java/com/example/demo/controller/LoginController.java
+++ b/src/main/java/com/example/demo/controller/LoginController.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import jakarta.servlet.http.HttpSession;
 
 import com.example.demo.entity.User;
 import com.example.demo.form.LogInForm;
@@ -44,13 +45,14 @@ public class LoginController {
     }
 	
     @PostMapping("/task-top")
-    public String showTop(LogInForm form, Model model) {
+    public String showTop(LogInForm form, Model model, HttpSession session) {
         User u = new User();
         u.setUsername(form.getUsername());
         u.setPassword(form.getPassword());
         log.debug("Attempting login for user: {}", form.getUsername());
         if (loginService.login(u)) {
             log.debug("Login success for user: {}", form.getUsername());
+            session.setAttribute("loginUser", form.getUsername());
             return "redirect:/" + form.getUsername() + "/task-top";
         } else {
             log.debug("Login failed for user: {}", form.getUsername());

--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
+import jakarta.servlet.http.HttpSession;
 import com.example.demo.form.TaskNameUpdate;
 import com.example.demo.form.ScheduleUpdateForm;
 
@@ -27,7 +28,11 @@ public class TaskListController {
     private final ScheduleService scheduleService;
 
     @GetMapping("/{username}/task-top")
-    public String showTaskTop(@PathVariable String username, Model model) {
+    public String showTaskTop(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
         log.debug("Displaying task top page");
         model.addAttribute("tasks", service.getAllTasks());
         var list = scheduleService.getAllSchedules().stream()
@@ -39,7 +44,11 @@ public class TaskListController {
     }
 
     @GetMapping("/{username}/task-top/task-box")
-    public String showTaskBox(@PathVariable String username, Model model) {
+    public String showTaskBox(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
         log.debug("Displaying task box page");
         var all = scheduleService.getAllSchedules();
         var completed = all.stream()


### PR DESCRIPTION
## Summary
- store login user in session after successful login
- verify session user on task list pages to require login

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685bf8f99138832ab2e4eedfa36a9d45