### PR TITLE
Implement login enforcement with interceptor

### DIFF
--- a/src/main/java/com/example/demo/config/LoginInterceptor.java
+++ b/src/main/java/com/example/demo/config/LoginInterceptor.java
@@ -1,0 +1,27 @@
+package com.example.demo.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class LoginInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        HttpSession session = request.getSession(false);
+        String loginUser = session != null ? (String) session.getAttribute("loginUser") : null;
+        if (loginUser == null) {
+            response.sendRedirect("/log-in");
+            return false;
+        }
+        String[] parts = request.getRequestURI().split("/");
+        if (parts.length > 1) {
+            String usernameFromPath = parts[1];
+            if (!loginUser.equals(usernameFromPath)) {
+                response.sendRedirect("/log-in");
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/example/demo/config/WebConfig.java
+++ b/src/main/java/com/example/demo/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LoginInterceptor())
+                .addPathPatterns("/**/task-top", "/**/task-top/**")
+                .excludePathPatterns("/task-top");
+    }
+}


### PR DESCRIPTION
## Summary
- add `LoginInterceptor` to send unauthenticated users to `/log-in`
- register the interceptor for `task-top` paths with `WebConfig`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd738718832aa3721ce9c70e1adf