### PR TITLE
Show total schedule points

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -123,4 +123,11 @@ public class TaskListController {
                 .filter(s -> s.getScheduleDate().getYear() == year && s.getScheduleDate().getMonthValue() == month)
                 .toList();
     }
+
+    @GetMapping("/total-point")
+    @ResponseBody
+    public Integer getTotalPoint() {
+        log.debug("Fetching total completed points");
+        return scheduleService.getTotalCompletedPoints();
+    }
 }

--- a/src/main/java/com/example/demo/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepository.java
@@ -15,4 +15,6 @@ public interface ScheduleRepository {
     void insertSchedule(Schedule schedule);
 
     void deleteById(int id);
+
+    int sumCompletedPoints();
 }

--- a/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/ScheduleRepositoryImpl.java
@@ -106,4 +106,11 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
         String sql = "DELETE FROM schedules WHERE id = ?";
         jdbcTemplate.update(sql, id);
     }
+
+    @Override
+    public int sumCompletedPoints() {
+        String sql = "SELECT COALESCE(SUM(point), 0) FROM schedules WHERE completed_day IS NOT NULL";
+        Integer result = jdbcTemplate.queryForObject(sql, Integer.class);
+        return result != null ? result : 0;
+    }
 }

--- a/src/main/java/com/example/demo/service/ScheduleService.java
+++ b/src/main/java/com/example/demo/service/ScheduleService.java
@@ -15,4 +15,6 @@ public interface ScheduleService {
     void addSchedule(Schedule schedule);
 
     void deleteScheduleById(int id);
+
+    int getTotalCompletedPoints();
 }

--- a/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/demo/service/ScheduleServiceImpl.java
@@ -70,4 +70,10 @@ public class ScheduleServiceImpl implements ScheduleService {
         log.debug("Deleting schedule with id {}", id);
         repository.deleteById(id);
     }
+
+    @Override
+    public int getTotalCompletedPoints() {
+        log.debug("Fetching total completed points");
+        return repository.sumCompletedPoints();
+    }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -49,6 +49,13 @@ body.task-body {
   left: 50px;
 }
 
+#total-point-display {
+  position: fixed;
+  top: 280px;
+  left: 50px;
+  font-weight: bold;
+}
+
 /* task-top.html だけの処理*/
 .calendar-area {
   position: absolute; /* 画面に固定，絶対位置，下にスクロールすると見えなくなる*/

--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -484,6 +484,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  const pointDisplay = document.getElementById('total-point-display');
+  if (pointDisplay) {
+    fetch('/total-point')
+      .then((res) => res.json())
+      .then((pt) => {
+        pointDisplay.textContent = `${pt}P`;
+      });
+  }
+
   sortAllTables(); //予定データベーステーブルを日付と時間の昇順に並べ替える,初期化
   initSchedules();//今表示されているカレンダーに予定を埋め込む
   document.addEventListener('calendarRendered', initSchedules);//calendarRendered というイベントが起きたら initSchedules 関数を実行．つまり，カレンダーの描画が終わってから，予定を埋め込むということ．

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -152,6 +152,7 @@
         <!-- cssとschedule.jsの両方 -->
         <button id="new-schedule-button">新規</button>
         <button id="toggle-completed-button">表示</button>
+        <div id="total-point-display"></div>
       </div>
 
       <div id="schedule-overlay" class="schedule-overlay"></div>


### PR DESCRIPTION
## Summary
- add endpoint to fetch total points for completed schedules
- compute total points in repository/service
- display total points below the toggle button
- style the total point display

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d60a54750832a8c5eeea259445cde