### PR TITLE
Update points after completion

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -79,6 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (res.ok) {
         row.dataset.oldTitle = data.title;
         row.dataset.oldDate = data.scheduleDate;
+        refreshTotalPoint();
       } else {
         console.error('Schedule update failed');
       }
@@ -488,13 +489,17 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const pointDisplay = document.getElementById('total-point-display');
-  if (pointDisplay) {
+
+  function refreshTotalPoint() {
+    if (!pointDisplay) return;
     fetch('/total-point')
       .then((res) => res.json())
       .then((pt) => {
         pointDisplay.textContent = `${pt}P`;
       });
   }
+
+  refreshTotalPoint();
 
   sortAllTables(); //予定データベーステーブルを日付と時間の昇順に並べ替える,初期化
   initSchedules();//今表示されているカレンダーに予定を埋め込む


### PR DESCRIPTION
## Summary
- refresh total points when a schedule is updated
- add helper to fetch the latest total points

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686124a8bb94832a9daee7041eb1a799