### PR TITLE
Fix missing Slf4j import

### DIFF
--- a/src/main/java/com/example/demo/controller/ScheduleController.java
+++ b/src/main/java/com/example/demo/controller/ScheduleController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import com.example.demo.service.ScheduleService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Controller
 @RequiredArgsConstructor


### PR DESCRIPTION
## Summary
- ensure ScheduleController logs correctly by importing `Slf4j`

## Testing
- `mvn -q test` *(fails: Could not resolve Spring artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6865080f93f8832a878b231ec30c8c9b