### PR TITLE
Add challenge creation button and backend handler

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.example.demo.entity.Schedule;
 import com.example.demo.entity.Task;
+import com.example.demo.entity.Challenge;
 import com.example.demo.form.ScheduleUpdateForm;
 import com.example.demo.form.TaskNameUpdate;
 import com.example.demo.service.ScheduleService;
@@ -108,6 +109,13 @@ public class TaskListController {
     public ResponseEntity<Void> addSchedule(@RequestBody Schedule schedule) {
         log.debug("Adding schedule {} on {}", schedule.getTitle(), schedule.getScheduleDate());
         scheduleService.addSchedule(schedule);//repository.insertSchedule(schedule)
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/challenge-add")
+    public ResponseEntity<Void> addChallenge(@RequestBody Challenge challenge) {
+        log.debug("Adding challenge {}", challenge.getTitle());
+        challengeService.addChallenge(challenge);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/demo/repository/challenge/ChallengeRepository.java
+++ b/src/main/java/com/example/demo/repository/challenge/ChallengeRepository.java
@@ -6,4 +6,5 @@ import com.example.demo.entity.Challenge;
 
 public interface ChallengeRepository {
     List<Challenge> findAll();
+    void insertChallenge(Challenge challenge);
 }

--- a/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
@@ -31,4 +31,10 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
             }
         });
     }
+
+    @Override
+    public void insertChallenge(Challenge challenge) {
+        String sql = "INSERT INTO challenges (title) VALUES (?)";
+        jdbcTemplate.update(sql, challenge.getTitle());
+    }
 }

--- a/src/main/java/com/example/demo/service/challenge/ChallengeService.java
+++ b/src/main/java/com/example/demo/service/challenge/ChallengeService.java
@@ -6,4 +6,5 @@ import com.example.demo.entity.Challenge;
 
 public interface ChallengeService {
     List<Challenge> getAllChallenges();
+    void addChallenge(Challenge challenge);
 }

--- a/src/main/java/com/example/demo/service/challenge/ChallengeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/challenge/ChallengeServiceImpl.java
@@ -22,4 +22,10 @@ public class ChallengeServiceImpl implements ChallengeService {
         log.debug("Fetching all challenges");
         return repository.findAll();
     }
+
+    @Override
+    public void addChallenge(Challenge challenge) {
+        log.debug("Adding challenge {}", challenge.getTitle());
+        repository.insertChallenge(challenge);
+    }
 }

--- a/src/main/resources/static/js/challenge.js
+++ b/src/main/resources/static/js/challenge.js
@@ -1,2 +1,15 @@
 //ページが全部読み込まれたら、中の処理を始める
-document.addEventListener('DOMContentLoaded', () => {});
+document.addEventListener('DOMContentLoaded', () => {
+  const newButton = document.getElementById('new-challenge-button');
+  if (newButton) {
+    newButton.addEventListener('click', () => {
+      fetch('/challenge-add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: '' })
+      }).then(() => {
+        location.reload();
+      });
+    });
+  }
+});

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -91,6 +91,7 @@
         <button id="new-schedule-button">新規</button>
         <button id="toggle-completed-button">表示</button>
         <div id="total-point-display"></div>
+        <button id="new-challenge-button">挑戦新規</button>
       </div>
 
       <div class="database-container">


### PR DESCRIPTION
## Summary
- display a new challenge button below the points display on task top page
- implement JS to handle creating a new challenge row
- add repository, service, and controller support for adding challenges

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6865392a1054832a99a5037af8d8a2b0