### PR TITLE
Update Challenge entity with new fields

### DIFF
--- a/src/main/java/com/example/demo/entity/Challenge.java
+++ b/src/main/java/com/example/demo/entity/Challenge.java
@@ -1,9 +1,18 @@
 package com.example.demo.entity;
 
+import java.time.LocalDate;
+
 import lombok.Data;
 
 @Data
 public class Challenge {
-    private int id;                  // ID
-    private String title;            // 予定名
+    private int id;                       // ID
+    private String title;                 // 予定名
+    private String risk;                  // リスクの説明
+    private String expectedResult;        // 目指す結果
+    private String strategy;              // 実行する戦略
+    private String actualResult;          // 実際の結果
+    private String improvementPlan;       // 改善策
+    private int challengeLevel;           // 難易度・挑戦度
+    private LocalDate challengeDate;      // 挑戦を始めた日
 }

--- a/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
@@ -20,13 +20,23 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
 
     @Override
     public List<Challenge> findAll() {
-        String sql = "SELECT id, title FROM challenges";
+        String sql = "SELECT id, title, risk, expected_result, strategy, actual_result, improvement_plan, challenge_level, challenge_date FROM challenges";
         return jdbcTemplate.query(sql, new RowMapper<Challenge>() {
             @Override
             public Challenge mapRow(ResultSet rs, int rowNum) throws SQLException {
                 Challenge c = new Challenge();
                 c.setId(rs.getInt("id"));
                 c.setTitle(rs.getString("title"));
+                c.setRisk(rs.getString("risk"));
+                c.setExpectedResult(rs.getString("expected_result"));
+                c.setStrategy(rs.getString("strategy"));
+                c.setActualResult(rs.getString("actual_result"));
+                c.setImprovementPlan(rs.getString("improvement_plan"));
+                c.setChallengeLevel(rs.getInt("challenge_level"));
+                java.sql.Date date = rs.getDate("challenge_date");
+                if (date != null) {
+                    c.setChallengeDate(date.toLocalDate());
+                }
                 return c;
             }
         });
@@ -34,7 +44,16 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
 
     @Override
     public void insertChallenge(Challenge challenge) {
-        String sql = "INSERT INTO challenges (title) VALUES (?)";
-        jdbcTemplate.update(sql, challenge.getTitle());
+        String sql = "INSERT INTO challenges (title, risk, expected_result, strategy, actual_result, improvement_plan, challenge_level, challenge_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        java.sql.Date date = challenge.getChallengeDate() != null ? java.sql.Date.valueOf(challenge.getChallengeDate()) : null;
+        jdbcTemplate.update(sql,
+                challenge.getTitle(),
+                challenge.getRisk(),
+                challenge.getExpectedResult(),
+                challenge.getStrategy(),
+                challenge.getActualResult(),
+                challenge.getImprovementPlan(),
+                challenge.getChallengeLevel(),
+                date);
     }
 }

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -95,20 +95,28 @@
       </div>
 
       <div class="database-container">
-        <table class="chalenge-database">
+          <table class="chalenge-database">
           <tr>
             <th>成功</th>
             <th>挑戦名</th>
-            <!-- <th>リスク</th>
+            <th>リスク</th>
             <th>求める結果</th>
             <th>戦略</th>
             <th>結果</th>
             <th>改善案</th>
-            <th>挑戦日</th> -->
+            <th>挑戦度</th>
+            <th>挑戦日</th>
           </tr>
           <tr th:each="challenge : ${challenges}" class="challenge-row" th:data-id="${challenge.id}">
             <td><input type="button" value="成功" class="challenge-suc-button" /></td>
             <td><input type="text" th:value="${challenge.title}" size="8" class="challenge-title-input" /></td>
+            <td><input type="text" th:value="${challenge.risk}" size="8" class="challenge-risk-input" /></td>
+            <td><input type="text" th:value="${challenge.expectedResult}" size="8" class="challenge-expected-input" /></td>
+            <td><input type="text" th:value="${challenge.strategy}" size="8" class="challenge-strategy-input" /></td>
+            <td><input type="text" th:value="${challenge.actualResult}" size="8" class="challenge-actual-input" /></td>
+            <td><input type="text" th:value="${challenge.improvementPlan}" size="8" class="challenge-improvement-input" /></td>
+            <td><input type="number" th:value="${challenge.challengeLevel}" class="challenge-level-input" /></td>
+            <td><input type="date" th:value="${challenge.challengeDate}" class="challenge-date-input" /></td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- extend `Challenge` entity with new database fields
- read/write new challenge columns in the repository
- show challenge details in the task-top page

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68653c60b4c0832ab1c69d5c6c768920