### PR TITLE
Change challenge level input

### DIFF
--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -115,7 +115,11 @@
             <td><input type="text" th:value="${challenge.strategy}" size="8" class="challenge-strategy-input" /></td>
             <td><input type="text" th:value="${challenge.actualResult}" size="8" class="challenge-actual-input" /></td>
             <td><input type="text" th:value="${challenge.improvementPlan}" size="8" class="challenge-improvement-input" /></td>
-            <td><input type="number" th:value="${challenge.challengeLevel}" class="challenge-level-input" /></td>
+            <td>
+              <select class="challenge-level-input">
+                <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == challenge.challengeLevel}"></option>
+              </select>
+            </td>
             <td><input type="date" th:value="${challenge.challengeDate}" class="challenge-date-input" /></td>
           </tr>
         </table>


### PR DESCRIPTION
## Summary
- replace numeric challenge level input with a select element ranging from 1 to 5

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686540d0a31c832a884663c80e837559