### PR TITLE
Add challenge box page with separate tables

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -70,6 +70,26 @@ public class TaskListController {
         return "task-box";
     }
 
+    @GetMapping("/{username}/task-top/challenge-box")
+    public String showChallengeBox(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying challenge box page");
+        var all = challengeService.getAllChallenges();
+        var unchallenged = all.stream()
+                .filter(c -> c.getActualResult() == null || c.getActualResult().isBlank())
+                .toList();
+        var completed = all.stream()
+                .filter(c -> c.getActualResult() != null && !c.getActualResult().isBlank())
+                .toList();
+        model.addAttribute("unchallenged", unchallenged);
+        model.addAttribute("completedChallenges", completed);
+        model.addAttribute("username", username);
+        return "challenge-box";
+    }
+
     @PostMapping("/task-confirm")
     public ResponseEntity<Void> updateConfirmed(@RequestBody Task task) {
         log.debug("Updating task confirm: {} {}", task.getTaskName(), task.isConfirmed());

--- a/src/main/resources/templates/challenge-box.html
+++ b/src/main/resources/templates/challenge-box.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>挑戦ボックス</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+    </div>
+
+    <div class="database-container">
+      <p>未挑戦</p>
+      <table id="unchallenged-table" class="chalenge-database">
+        <tr>
+          <th>成功</th>
+          <th>挑戦名</th>
+          <th>リスク</th>
+          <th>求める結果</th>
+          <th>戦略</th>
+          <th>結果</th>
+          <th>改善案</th>
+          <th>挑戦度</th>
+          <th>挑戦日</th>
+        </tr>
+        <tr th:each="challenge : ${unchallenged}" class="challenge-row" th:data-id="${challenge.id}">
+          <td><input type="button" value="成功" class="challenge-suc-button" /></td>
+          <td><input type="text" th:value="${challenge.title}" size="8" class="challenge-title-input" /></td>
+          <td><input type="text" th:value="${challenge.risk}" size="8" class="challenge-risk-input" /></td>
+          <td><input type="text" th:value="${challenge.expectedResult}" size="8" class="challenge-expected-input" /></td>
+          <td><input type="text" th:value="${challenge.strategy}" size="8" class="challenge-strategy-input" /></td>
+          <td><input type="text" th:value="${challenge.actualResult}" size="8" class="challenge-actual-input" /></td>
+          <td><input type="text" th:value="${challenge.improvementPlan}" size="8" class="challenge-improvement-input" /></td>
+          <td>
+            <select class="challenge-level-input">
+              <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == challenge.challengeLevel}"></option>
+            </select>
+          </td>
+          <td><input type="date" th:value="${challenge.challengeDate}" class="challenge-date-input" /></td>
+        </tr>
+      </table>
+      <button id="new-challenge-button">新規</button>
+    </div>
+
+    <div class="database-container">
+      <p>挑戦済み</p>
+      <table id="completed-challenge-table" class="chalenge-database">
+        <tr>
+          <th>成功</th>
+          <th>挑戦名</th>
+          <th>リスク</th>
+          <th>求める結果</th>
+          <th>戦略</th>
+          <th>結果</th>
+          <th>改善案</th>
+          <th>挑戦度</th>
+          <th>挑戦日</th>
+        </tr>
+        <tr th:each="challenge : ${completedChallenges}" class="challenge-row" th:data-id="${challenge.id}">
+          <td><input type="button" value="成功" class="challenge-suc-button" /></td>
+          <td><input type="text" th:value="${challenge.title}" size="8" class="challenge-title-input" /></td>
+          <td><input type="text" th:value="${challenge.risk}" size="8" class="challenge-risk-input" /></td>
+          <td><input type="text" th:value="${challenge.expectedResult}" size="8" class="challenge-expected-input" /></td>
+          <td><input type="text" th:value="${challenge.strategy}" size="8" class="challenge-strategy-input" /></td>
+          <td><input type="text" th:value="${challenge.actualResult}" size="8" class="challenge-actual-input" /></td>
+          <td><input type="text" th:value="${challenge.improvementPlan}" size="8" class="challenge-improvement-input" /></td>
+          <td>
+            <select class="challenge-level-input">
+              <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == challenge.challengeLevel}"></option>
+            </select>
+          </td>
+          <td><input type="date" th:value="${challenge.challengeDate}" class="challenge-date-input" /></td>
+        </tr>
+      </table>
+    </div>
+
+    <script th:src="@{/js/challenge.js}"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -8,10 +8,10 @@
     </head>
     <body class="task-body">
       <div class="link-area">
-        <a href="challenge-box.html">挑戦ボックス</a>
+        <a th:href="@{'/' + ${username} + '/task-top/challenge-box'}">挑戦ボックス</a>
         <a href="question-survey-box.html">疑問・調査ボックス</a>
-        <a th:href="@{'/' + ${username} + '/task-top/task-box'}">タスクボックス</a
-        ><!-- java変数などを埋め込める動的リンクを生成（Thymeleaf使用） @{URLパターン}，java側でusernameをmodel.addAttributeしてる-->
+        <a th:href="@{'/' + ${username} + '/task-top/task-box'}">タスクボックス</a>
+        <!-- java変数などを埋め込める動的リンクを生成（Thymeleaf使用） @{URLパターン}，java側でusernameをmodel.addAttributeしてる-->
       </div>
 
       <div id="calendar" class="calendar-area"></div>


### PR DESCRIPTION
## Summary
- add `challenge-box.html` template with tables for unchallenged and completed challenges
- add `showChallengeBox` handler in `TaskListController`
- link to the new page from task-top

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686547a6b064832a89322c568fbbce9e