### PR TITLE
Add challenge management buttons

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -139,6 +139,20 @@ public class TaskListController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/challenge-update")
+    public ResponseEntity<Void> updateChallenge(@RequestBody Challenge challenge) {
+        log.debug("Updating challenge id {}", challenge.getId());
+        challengeService.updateChallenge(challenge);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/challenge-delete")
+    public ResponseEntity<Void> deleteChallenge(@RequestBody Challenge challenge) {
+        log.debug("Deleting challenge id {}", challenge.getId());
+        challengeService.deleteById(challenge.getId());
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/schedule-delete")
     public ResponseEntity<Void> deleteSchedule(@RequestBody Schedule schedule) {
         log.debug("Deleting schedule id {}", schedule.getId());

--- a/src/main/java/com/example/demo/repository/challenge/ChallengeRepository.java
+++ b/src/main/java/com/example/demo/repository/challenge/ChallengeRepository.java
@@ -7,4 +7,6 @@ import com.example.demo.entity.Challenge;
 public interface ChallengeRepository {
     List<Challenge> findAll();
     void insertChallenge(Challenge challenge);
+    void updateChallenge(Challenge challenge);
+    void deleteById(int id);
 }

--- a/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
@@ -56,4 +56,26 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
                 challenge.getChallengeLevel(),
                 date);
     }
+
+    @Override
+    public void updateChallenge(Challenge challenge) {
+        String sql = "UPDATE challenges SET title = ?, risk = ?, expected_result = ?, strategy = ?, actual_result = ?, improvement_plan = ?, challenge_level = ?, challenge_date = ? WHERE id = ?";
+        java.sql.Date date = challenge.getChallengeDate() != null ? java.sql.Date.valueOf(challenge.getChallengeDate()) : null;
+        jdbcTemplate.update(sql,
+                challenge.getTitle(),
+                challenge.getRisk(),
+                challenge.getExpectedResult(),
+                challenge.getStrategy(),
+                challenge.getActualResult(),
+                challenge.getImprovementPlan(),
+                challenge.getChallengeLevel(),
+                date,
+                challenge.getId());
+    }
+
+    @Override
+    public void deleteById(int id) {
+        String sql = "DELETE FROM challenges WHERE id = ?";
+        jdbcTemplate.update(sql, id);
+    }
 }

--- a/src/main/java/com/example/demo/service/challenge/ChallengeService.java
+++ b/src/main/java/com/example/demo/service/challenge/ChallengeService.java
@@ -7,4 +7,6 @@ import com.example.demo.entity.Challenge;
 public interface ChallengeService {
     List<Challenge> getAllChallenges();
     void addChallenge(Challenge challenge);
+    void updateChallenge(Challenge challenge);
+    void deleteById(int id);
 }

--- a/src/main/java/com/example/demo/service/challenge/ChallengeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/challenge/ChallengeServiceImpl.java
@@ -28,4 +28,16 @@ public class ChallengeServiceImpl implements ChallengeService {
         log.debug("Adding challenge {}", challenge.getTitle());
         repository.insertChallenge(challenge);
     }
+
+    @Override
+    public void updateChallenge(Challenge challenge) {
+        log.debug("Updating challenge id {}", challenge.getId());
+        repository.updateChallenge(challenge);
+    }
+
+    @Override
+    public void deleteById(int id) {
+        log.debug("Deleting challenge with id {}", id);
+        repository.deleteById(id);
+    }
 }

--- a/src/main/resources/static/js/challenge.js
+++ b/src/main/resources/static/js/challenge.js
@@ -12,4 +12,74 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   }
+
+  const unchallengedTable = document.getElementById('unchallenged-table');
+  const completedTable = document.getElementById('completed-challenge-table');
+
+  function moveRow(row, completed) {
+    const target = completed ? completedTable : unchallengedTable;
+    if (!row || !target) return;
+    const tbody = target.tBodies[0] || target;
+    tbody.appendChild(row);
+  }
+
+  function gatherData(row) {
+    return {
+      id: parseInt(row.dataset.id, 10),
+      title: row.querySelector('.challenge-title-input').value,
+      risk: row.querySelector('.challenge-risk-input').value,
+      expectedResult: row.querySelector('.challenge-expected-input').value,
+      strategy: row.querySelector('.challenge-strategy-input').value,
+      actualResult: row.querySelector('.challenge-actual-input').value,
+      improvementPlan: row.querySelector('.challenge-improvement-input').value,
+      challengeLevel: parseInt(row.querySelector('.challenge-level-input').value, 10),
+      challengeDate: row.querySelector('.challenge-date-input').value || null
+    };
+  }
+
+  function sendUpdate(row) {
+    const data = gatherData(row);
+    fetch('/challenge-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+
+  document.querySelectorAll('.challenge-suc-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const input = row.querySelector('.challenge-actual-input');
+      if (input) input.value = '成功';
+      sendUpdate(row);
+      moveRow(row, true);
+    });
+  });
+
+  document.querySelectorAll('.challenge-fail-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const input = row.querySelector('.challenge-actual-input');
+      if (input) input.value = '失敗';
+      sendUpdate(row);
+      moveRow(row, true);
+    });
+  });
+
+  document.querySelectorAll('.challenge-delete-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/challenge-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) })
+      }).then(() => {
+        row.remove();
+      });
+    });
+  });
 });

--- a/src/main/resources/templates/challenge-box.html
+++ b/src/main/resources/templates/challenge-box.html
@@ -15,6 +15,7 @@
       <table id="unchallenged-table" class="chalenge-database">
         <tr>
           <th>成功</th>
+          <th>削除</th>
           <th>挑戦名</th>
           <th>リスク</th>
           <th>求める結果</th>
@@ -25,7 +26,11 @@
           <th>挑戦日</th>
         </tr>
         <tr th:each="challenge : ${unchallenged}" class="challenge-row" th:data-id="${challenge.id}">
-          <td><input type="button" value="成功" class="challenge-suc-button" /></td>
+          <td>
+            <input type="button" value="成功" class="challenge-suc-button" />
+            <input type="button" value="失敗" class="challenge-fail-button" />
+          </td>
+          <td><input type="button" value="削除" class="challenge-delete-button" /></td>
           <td><input type="text" th:value="${challenge.title}" size="8" class="challenge-title-input" /></td>
           <td><input type="text" th:value="${challenge.risk}" size="8" class="challenge-risk-input" /></td>
           <td><input type="text" th:value="${challenge.expectedResult}" size="8" class="challenge-expected-input" /></td>
@@ -48,6 +53,7 @@
       <table id="completed-challenge-table" class="chalenge-database">
         <tr>
           <th>成功</th>
+          <th>削除</th>
           <th>挑戦名</th>
           <th>リスク</th>
           <th>求める結果</th>
@@ -58,7 +64,11 @@
           <th>挑戦日</th>
         </tr>
         <tr th:each="challenge : ${completedChallenges}" class="challenge-row" th:data-id="${challenge.id}">
-          <td><input type="button" value="成功" class="challenge-suc-button" /></td>
+          <td>
+            <input type="button" value="成功" class="challenge-suc-button" />
+            <input type="button" value="失敗" class="challenge-fail-button" />
+          </td>
+          <td><input type="button" value="削除" class="challenge-delete-button" /></td>
           <td><input type="text" th:value="${challenge.title}" size="8" class="challenge-title-input" /></td>
           <td><input type="text" th:value="${challenge.risk}" size="8" class="challenge-risk-input" /></td>
           <td><input type="text" th:value="${challenge.expectedResult}" size="8" class="challenge-expected-input" /></td>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -98,6 +98,7 @@
           <table class="chalenge-database">
           <tr>
             <th>成功</th>
+            <th>削除</th>
             <th>挑戦名</th>
             <th>リスク</th>
             <th>求める結果</th>
@@ -108,7 +109,11 @@
             <th>挑戦日</th>
           </tr>
           <tr th:each="challenge : ${challenges}" class="challenge-row" th:data-id="${challenge.id}">
-            <td><input type="button" value="成功" class="challenge-suc-button" /></td>
+            <td>
+              <input type="button" value="成功" class="challenge-suc-button" />
+              <input type="button" value="失敗" class="challenge-fail-button" />
+            </td>
+            <td><input type="button" value="削除" class="challenge-delete-button" /></td>
             <td><input type="text" th:value="${challenge.title}" size="8" class="challenge-title-input" /></td>
             <td><input type="text" th:value="${challenge.risk}" size="8" class="challenge-risk-input" /></td>
             <td><input type="text" th:value="${challenge.expectedResult}" size="8" class="challenge-expected-input" /></td>


### PR DESCRIPTION
## Summary
- add update and delete features in challenge repository/service/controller
- add success/fail/delete buttons in challenge templates
- update challenge JS to handle new buttons

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68654b000ce8832a869e84cea85fa2c7