### PR TITLE
Filter unchallenged challenges on top page

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskListController.java
+++ b/src/main/java/com/example/demo/controller/TaskListController.java
@@ -45,7 +45,10 @@ public class TaskListController {
                 .filter(s -> s.getCompletedDay() == null)
                 .toList();
         model.addAttribute("schedules", list);
-        model.addAttribute("challenges", challengeService.getAllChallenges());
+        var challengeList = challengeService.getAllChallenges().stream()
+                .filter(c -> c.getChallengeDate() == null)
+                .toList();
+        model.addAttribute("challenges", challengeList);
         model.addAttribute("username", username);
         return "task-top";
     }

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -108,7 +108,7 @@
             <th>挑戦度</th>
             <th>挑戦日</th>
           </tr>
-          <tr th:each="challenge : ${challenges}" class="challenge-row" th:data-id="${challenge.id}">
+          <tr th:each="challenge : ${challenges}" th:if="${challenge.challengeDate} == null" class="challenge-row" th:data-id="${challenge.id}">
             <td>
               <input type="button" value="成功" class="challenge-suc-button" />
               <input type="button" value="失敗" class="challenge-fail-button" />


### PR DESCRIPTION
## Summary
- filter challenges in `TaskListController` so the top page only sees ones with no `challengeDate`
- guard the HTML rows so only unchallenged entries render

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68655b6e35e4832abc04fa70eab7659a