### PR TITLE
Add challenge difficulty points to total

### DIFF
--- a/src/main/java/com/example/demo/controller/ScheduleController.java
+++ b/src/main/java/com/example/demo/controller/ScheduleController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.example.demo.service.ScheduleService;
+import com.example.demo.service.challenge.ChallengeService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,12 +15,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ScheduleController {
 	
-	private final ScheduleService scheduleService;
+        private final ScheduleService scheduleService;
+        private final ChallengeService challengeService;
 	@GetMapping("/total-point")
     @ResponseBody
     public Integer getTotalPoint() {
        log.debug("Fetching total completed points");
-        return scheduleService.getTotalCompletedPoints();//@ResponseBodyによって，htmlではなく，interger型のデータ（ポイント）をreturn
+        int schedulePoints = scheduleService.getTotalCompletedPoints();
+        int challengePoints = challengeService.getTotalCompletedPoints();
+        return schedulePoints + challengePoints;//@ResponseBodyによって，htmlではなく，interger型のデータ（ポイント）をreturn
     }
 
 }

--- a/src/main/java/com/example/demo/repository/challenge/ChallengeRepository.java
+++ b/src/main/java/com/example/demo/repository/challenge/ChallengeRepository.java
@@ -9,4 +9,5 @@ public interface ChallengeRepository {
     void insertChallenge(Challenge challenge);
     void updateChallenge(Challenge challenge);
     void deleteById(int id);
+    int sumCompletedPoints();
 }

--- a/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
@@ -78,4 +78,11 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
         String sql = "DELETE FROM challenges WHERE id = ?";
         jdbcTemplate.update(sql, id);
     }
+
+    @Override
+    public int sumCompletedPoints() {
+        String sql = "SELECT COALESCE(SUM(challenge_level * 2), 0) FROM challenges WHERE challenge_date IS NOT NULL";
+        Integer result = jdbcTemplate.queryForObject(sql, Integer.class);
+        return result != null ? result : 0;
+    }
 }

--- a/src/main/java/com/example/demo/service/challenge/ChallengeService.java
+++ b/src/main/java/com/example/demo/service/challenge/ChallengeService.java
@@ -9,4 +9,5 @@ public interface ChallengeService {
     void addChallenge(Challenge challenge);
     void updateChallenge(Challenge challenge);
     void deleteById(int id);
+    int getTotalCompletedPoints();
 }

--- a/src/main/java/com/example/demo/service/challenge/ChallengeServiceImpl.java
+++ b/src/main/java/com/example/demo/service/challenge/ChallengeServiceImpl.java
@@ -40,4 +40,10 @@ public class ChallengeServiceImpl implements ChallengeService {
         log.debug("Deleting challenge with id {}", id);
         repository.deleteById(id);
     }
+
+    @Override
+    public int getTotalCompletedPoints() {
+        log.debug("Fetching total challenge points");
+        return repository.sumCompletedPoints();
+    }
 }

--- a/src/main/resources/static/js/challenge.js
+++ b/src/main/resources/static/js/challenge.js
@@ -15,6 +15,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const unchallengedTable = document.getElementById('unchallenged-table');
   const completedTable = document.getElementById('completed-challenge-table');
+  const pointDisplay = document.getElementById('total-point-display');
+
+  function refreshTotalPoint() {
+    if (!pointDisplay) return;
+    fetch('/total-point')
+      .then((res) => res.json())
+      .then((pt) => {
+        pointDisplay.textContent = `${pt}P`;
+      });
+  }
 
   function moveRow(row, toCompleted) {
     if (!row) return;
@@ -77,6 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
       sendUpdate(row);
       moveRow(row, true);
       replaceWithCancel(row);
+      refreshTotalPoint();
     });
   }
 
@@ -91,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
       sendUpdate(row);
       moveRow(row, true);
       replaceWithCancel(row);
+      refreshTotalPoint();
     });
   }
 
@@ -105,6 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
       sendUpdate(row);
       moveRow(row, false);
       replaceWithSucFail(row);
+      refreshTotalPoint();
     });
   }
 
@@ -126,4 +139,6 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   });
+
+  refreshTotalPoint();
 });


### PR DESCRIPTION
## Summary
- sum completed challenge points in the repository and service
- include challenge points when returning `/total-point`
- refresh total point from challenge page when results change

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68656389d0b4832a88e663a11a0616ad