### PR TITLE
Adjust challenge points based on success/failure

### DIFF
--- a/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/challenge/ChallengeRepositoryImpl.java
@@ -81,7 +81,11 @@ public class ChallengeRepositoryImpl implements ChallengeRepository {
 
     @Override
     public int sumCompletedPoints() {
-        String sql = "SELECT COALESCE(SUM(challenge_level * 2), 0) FROM challenges WHERE challenge_date IS NOT NULL";
+        String sql = "SELECT COALESCE(SUM(CASE actual_result "
+                + "WHEN '成功' THEN challenge_level * 2 "
+                + "WHEN '失敗' THEN challenge_level "
+                + "ELSE 0 END), 0) "
+                + "FROM challenges WHERE challenge_date IS NOT NULL";
         Integer result = jdbcTemplate.queryForObject(sql, Integer.class);
         return result != null ? result : 0;
     }


### PR DESCRIPTION
## Summary
- modify challenge repository to give 2x points on success and 1x on failure

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6865678d7ea0832a8365f4e0665cfb39