### PR TITLE
Fix new challenge button position

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -56,6 +56,12 @@ body.task-body {
   font-weight: bold;
 }
 
+#new-challenge-button {
+  position: fixed;
+  top: 320px;
+  left: 50px;
+}
+
 /* task-top.html だけの処理*/
 
 .calendar-area {


### PR DESCRIPTION
## Summary
- move the `new-challenge-button` under the total point display

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686896a51b20832a8b88b84b3d9b9489