### PR TITLE
Enable editable tasks and remove metadata columns

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskController.java
+++ b/src/main/java/com/example/demo/controller/TaskController.java
@@ -1,0 +1,41 @@
+package com.example.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.Task;
+import com.example.demo.service.task.TaskService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class TaskController {
+
+    private final TaskService taskService;
+
+    @PostMapping("/task-add")
+    public ResponseEntity<Void> addTask(@RequestBody Task task) {
+        log.debug("Adding task {}", task.getTitle());
+        taskService.addTask(task);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/task-update")
+    public ResponseEntity<Void> updateTask(@RequestBody Task task) {
+        log.debug("Updating task id {}", task.getId());
+        taskService.updateTask(task);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/task-delete")
+    public ResponseEntity<Void> deleteTask(@RequestBody Task task) {
+        log.debug("Deleting task id {}", task.getId());
+        taskService.deleteTaskById(task.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/repository/task/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepository.java
@@ -6,4 +6,7 @@ import com.example.demo.entity.Task;
 
 public interface TaskRepository {
     List<Task> findAll();
+    void insertTask(Task task);
+    void updateTask(Task task);
+    void deleteById(int id);
 }

--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -53,4 +53,35 @@ public class TaskRepositoryImpl implements TaskRepository {
             }
         });
     }
+
+    @Override
+    public void insertTask(Task task) {
+        String sql = "INSERT INTO tasks (title, category, due_date, result, detail, level, created_at, updated_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)";
+        java.sql.Date due = task.getDueDate() != null ? java.sql.Date.valueOf(task.getDueDate()) : null;
+        java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
+        jdbcTemplate.update(sql,
+                task.getTitle(),
+                task.getCategory(),
+                due,
+                task.getResult(),
+                task.getDetail(),
+                task.getLevel(),
+                completed);
+    }
+
+    @Override
+    public void updateTask(Task task) {
+        String sql = "UPDATE tasks SET title = ?, result = ?, detail = ?, updated_at = NOW() WHERE id = ?";
+        jdbcTemplate.update(sql,
+                task.getTitle(),
+                task.getResult(),
+                task.getDetail(),
+                task.getId());
+    }
+
+    @Override
+    public void deleteById(int id) {
+        String sql = "DELETE FROM tasks WHERE id = ?";
+        jdbcTemplate.update(sql, id);
+    }
 }

--- a/src/main/java/com/example/demo/service/task/TaskService.java
+++ b/src/main/java/com/example/demo/service/task/TaskService.java
@@ -6,4 +6,10 @@ import com.example.demo.entity.Task;
 
 public interface TaskService {
     List<Task> getAllTasks();
+
+    void addTask(Task task);
+
+    void updateTask(Task task);
+
+    void deleteTaskById(int id);
 }

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -22,4 +22,22 @@ public class TaskServiceImpl implements TaskService {
         log.debug("Fetching all tasks");
         return repository.findAll();
     }
+
+    @Override
+    public void addTask(Task task) {
+        log.debug("Adding task {}", task.getTitle());
+        repository.insertTask(task);
+    }
+
+    @Override
+    public void updateTask(Task task) {
+        log.debug("Updating task id {}", task.getId());
+        repository.updateTask(task);
+    }
+
+    @Override
+    public void deleteTaskById(int id) {
+        log.debug("Deleting task with id {}", id);
+        repository.deleteById(id);
+    }
 }

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -1,0 +1,41 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const newButton = document.getElementById('new-task-button');
+  if (newButton) {
+    newButton.addEventListener('click', () => {
+      fetch('/task-add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: '', result: '', detail: '' })
+      }).then(() => location.reload());
+    });
+  }
+
+  function gatherData(row) {
+    return {
+      id: parseInt(row.dataset.id, 10),
+      title: row.querySelector('.task-title-input').value,
+      result: row.querySelector('.task-result-input').value,
+      detail: row.querySelector('.task-detail-input').value
+    };
+  }
+
+  function sendUpdate(row) {
+    const data = gatherData(row);
+    fetch('/task-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+
+  ['.task-title-input', '.task-result-input', '.task-detail-input'].forEach((selector) => {
+    document.querySelectorAll(selector).forEach((inp) => {
+      const handler = () => {
+        const row = inp.closest('tr');
+        if (row) sendUpdate(row);
+      };
+      inp.addEventListener('change', handler);
+      inp.addEventListener('input', handler);
+    });
+  });
+});

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -133,30 +133,25 @@
       <div class="database-container">
         <table class="database-table">
           <tr>
-            <th>ID</th>
             <th>タスク名</th>
             <th>区分</th>
             <th>期日</th>
             <th>結果</th>
             <th>詳細</th>
             <th>レベル</th>
-            <th>作成日</th>
-            <th>更新日</th>
             <th>完了日</th>
           </tr>
-          <tr th:each="task : ${tasks}">
-            <td th:text="${task.id}"></td>
-            <td th:text="${task.title}"></td>
+          <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
+            <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
             <td th:text="${task.category}"></td>
             <td th:text="${task.dueDate}"></td>
-            <td th:text="${task.result}"></td>
-            <td th:text="${task.detail}"></td>
+            <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
+            <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>
             <td th:text="${task.level}"></td>
-            <td th:text="${task.createdAt}"></td>
-            <td th:text="${task.updatedAt}"></td>
             <td th:text="${task.completedAt}"></td>
           </tr>
         </table>
+        <button id="new-task-button">タスク新規</button>
       </div>
 
       <div id="schedule-overlay" class="schedule-overlay"></div>
@@ -170,6 +165,7 @@
       <script th:src="@{/js/calende.js}"></script>
       <script th:src="@{/js/challenge.js}"></script>
       <script th:src="@{/js/schedule.js}"></script>
+      <script th:src="@{/js/task.js}"></script>
       <script th:src="@{/js/calendar-detail.js}"></script>
     </body>
   </html>


### PR DESCRIPTION
## Summary
- hide ID, created and updated columns for tasks
- allow editing task title/result/detail
- store new/updated tasks via new controller and repository methods
- add JavaScript to handle task CRUD actions

## Testing
- `mvn -q -e -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a733bf760832a973296abd19d7ec0