### PR TITLE
Enable task level selection

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -71,11 +71,12 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void updateTask(Task task) {
-        String sql = "UPDATE tasks SET title = ?, result = ?, detail = ?, updated_at = NOW() WHERE id = ?";
+        String sql = "UPDATE tasks SET title = ?, result = ?, detail = ?, level = ?, updated_at = NOW() WHERE id = ?";
         jdbcTemplate.update(sql,
                 task.getTitle(),
                 task.getResult(),
                 task.getDetail(),
+                task.getLevel(),
                 task.getId());
     }
 

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch('/task-add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: '', result: '', detail: '' })
+        body: JSON.stringify({ title: '', result: '', detail: '', level: 1 })
       }).then(() => location.reload());
     });
   }
@@ -15,7 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
       id: parseInt(row.dataset.id, 10),
       title: row.querySelector('.task-title-input').value,
       result: row.querySelector('.task-result-input').value,
-      detail: row.querySelector('.task-detail-input').value
+      detail: row.querySelector('.task-detail-input').value,
+      level: parseInt(row.querySelector('.task-level-select').value, 10)
     };
   }
 
@@ -28,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  ['.task-title-input', '.task-result-input', '.task-detail-input'].forEach((selector) => {
+  ['.task-title-input', '.task-result-input', '.task-detail-input', '.task-level-select'].forEach((selector) => {
     document.querySelectorAll(selector).forEach((inp) => {
       const handler = () => {
         const row = inp.closest('tr');

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -140,16 +140,20 @@
             <th>期日</th>
             <th>結果</th>
             <th>詳細</th>
-            <th>レベル</th>
-            <th>完了日</th>
-          </tr>
-          <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
+              <th>レベル</th>
+              <th>完了日</th>
+            </tr>
+            <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
             <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
             <td th:text="${task.category}"></td>
             <td th:text="${task.dueDate}"></td>
             <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
-            <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>
-            <td th:text="${task.level}"></td>
+              <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>
+              <td>
+                <select class="task-level-select">
+                  <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == task.level}"></option>
+                </select>
+              </td>
             <td th:text="${task.completedAt}"></td>
           </tr>
         </table>


### PR DESCRIPTION
## Summary
- allow updating `Task` level in JDBC repository
- add level selector in task HTML template
- send level to backend in JS when tasks are added or updated

## Testing
- `./mvnw -q test` *(fails: Could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a79829828832abaa7277f29925fc7