### PR TITLE
Add completion control for tasks

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -71,12 +71,14 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void updateTask(Task task) {
-        String sql = "UPDATE tasks SET title = ?, result = ?, detail = ?, level = ?, updated_at = NOW() WHERE id = ?";
+        String sql = "UPDATE tasks SET title = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
+        java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
         jdbcTemplate.update(sql,
                 task.getTitle(),
                 task.getResult(),
                 task.getDetail(),
                 task.getLevel(),
+                completed,
                 task.getId());
     }
 

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -16,7 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
       title: row.querySelector('.task-title-input').value,
       result: row.querySelector('.task-result-input').value,
       detail: row.querySelector('.task-detail-input').value,
-      level: parseInt(row.querySelector('.task-level-select').value, 10)
+      level: parseInt(row.querySelector('.task-level-select').value, 10),
+      completedAt: row.querySelector('.task-completed-input').value || null
     };
   }
 
@@ -29,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  ['.task-title-input', '.task-result-input', '.task-detail-input', '.task-level-select'].forEach((selector) => {
+  ['.task-title-input', '.task-result-input', '.task-detail-input', '.task-level-select', '.task-completed-input'].forEach((selector) => {
     document.querySelectorAll(selector).forEach((inp) => {
       const handler = () => {
         const row = inp.closest('tr');
@@ -37,6 +38,25 @@ document.addEventListener('DOMContentLoaded', () => {
       };
       inp.addEventListener('change', handler);
       inp.addEventListener('input', handler);
+    });
+  });
+
+  document.querySelectorAll('.task-complete-button').forEach((btn) => {
+    const row = btn.closest('tr');
+    const comp = row ? row.querySelector('.task-completed-input') : null;
+    if (comp && comp.value) {
+      btn.value = '取消';
+    }
+    btn.addEventListener('click', () => {
+      if (!row || !comp) return;
+      if (btn.value === '完了') {
+        comp.value = new Date().toISOString().split('T')[0];
+        btn.value = '取消';
+      } else {
+        comp.value = '';
+        btn.value = '完了';
+      }
+      sendUpdate(row);
     });
   });
 });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -135,6 +135,7 @@
       <div class="database-container">
         <table class="task-database">
           <tr>
+            <th>報告</th>
             <th>タスク名</th>
             <th>区分</th>
             <th>期日</th>
@@ -143,8 +144,9 @@
               <th>レベル</th>
               <th>完了日</th>
             </tr>
-            <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
-            <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
+          <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
+          <td><input type="button" value="完了" class="task-complete-button" /></td>
+          <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
             <td th:text="${task.category}"></td>
             <td th:text="${task.dueDate}"></td>
             <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
@@ -154,7 +156,7 @@
                   <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == task.level}"></option>
                 </select>
               </td>
-            <td th:text="${task.completedAt}"></td>
+            <td><input type="date" th:value="${task.completedAt}" class="task-completed-input" /></td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- add a `報告` column to the task table with a completion button
- show a date input for `completedAt`
- send `completedAt` on update and toggle via button
- update repository SQL to persist `completed_at`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a7c32835c832ab3fce7657dfcc0af