### PR TITLE
Enable category selection for tasks

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -41,7 +41,9 @@ public class TopController {
                 .filter(c -> c.getChallengeDate() == null)
                 .toList();
         model.addAttribute("challenges", challengeList);
-        var taskList = taskService.getAllTasks();
+        var taskList = taskService.getAllTasks().stream()
+                .filter(t -> t.getCompletedAt() == null)
+                .toList();
         model.addAttribute("tasks", taskList);
         model.addAttribute("username", username);
         return "task-top";

--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -71,10 +71,11 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void updateTask(Task task) {
-        String sql = "UPDATE tasks SET title = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
+        String sql = "UPDATE tasks SET title = ?, category = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
         java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
         jdbcTemplate.update(sql,
                 task.getTitle(),
+                task.getCategory(),
                 task.getResult(),
                 task.getDetail(),
                 task.getLevel(),

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch('/task-add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: '', result: '', detail: '', level: 1 })
+        body: JSON.stringify({ title: '', category: '今日', result: '', detail: '', level: 1 })
       }).then(() => location.reload());
     });
   }
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return {
       id: parseInt(row.dataset.id, 10),
       title: row.querySelector('.task-title-input').value,
+      category: row.querySelector('.task-category-select').value,
       result: row.querySelector('.task-result-input').value,
       detail: row.querySelector('.task-detail-input').value,
       level: parseInt(row.querySelector('.task-level-select').value, 10),
@@ -30,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  ['.task-title-input', '.task-result-input', '.task-detail-input', '.task-level-select', '.task-completed-input'].forEach((selector) => {
+  ['.task-title-input', '.task-result-input', '.task-detail-input', '.task-level-select', '.task-completed-input', '.task-category-select'].forEach((selector) => {
     document.querySelectorAll(selector).forEach((inp) => {
       const handler = () => {
         const row = inp.closest('tr');
@@ -46,15 +47,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const comp = row ? row.querySelector('.task-completed-input') : null;
     if (comp && comp.value) {
       btn.value = '取消';
+      if (row) row.style.display = 'none';
     }
     btn.addEventListener('click', () => {
       if (!row || !comp) return;
       if (btn.value === '完了') {
         comp.value = new Date().toISOString().split('T')[0];
         btn.value = '取消';
+        row.style.display = 'none';
       } else {
         comp.value = '';
         btn.value = '完了';
+        row.style.display = '';
       }
       sendUpdate(row);
     });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -147,7 +147,15 @@
           <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
           <td><input type="button" value="完了" class="task-complete-button" /></td>
           <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
-            <td th:text="${task.category}"></td>
+            <td>
+              <select class="task-category-select">
+                <option value="今日" th:selected="${task.category == '今日'}">今日</option>
+                <option value="明日" th:selected="${task.category == '明日'}">明日</option>
+                <option value="今週" th:selected="${task.category == '今週'}">今週</option>
+                <option value="来週" th:selected="${task.category == '来週'}">来週</option>
+                <option value="再来週" th:selected="${task.category == '再来週'}">再来週</option>
+              </select>
+            </td>
             <td th:text="${task.dueDate}"></td>
             <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
               <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>


### PR DESCRIPTION
## Summary
- let users choose a category for tasks from predefined options
- hide completed tasks and don't load them on the top page
- include category updates in repository updates

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a7e452fc8832a87aae38fca0c0658