### PR TITLE
Add dynamic task deadlines

### DIFF
--- a/src/main/java/com/example/demo/entity/Task.java
+++ b/src/main/java/com/example/demo/entity/Task.java
@@ -11,6 +11,7 @@ public class Task {
     private String title; // タスク名
     private String category; // 区分
     private LocalDate dueDate; // 期日
+    private String timeUntilDue; // 期日までを表す文字列
     private String result; // 結果
     private String detail; // 詳細
     private int level; // レベル

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -156,7 +156,7 @@
                 <option value="再来週" th:selected="${task.category == '再来週'}">再来週</option>
               </select>
             </td>
-            <td th:text="${task.dueDate}"></td>
+            <td th:text="${task.timeUntilDue}"></td>
             <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
               <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>
               <td>


### PR DESCRIPTION
## Summary
- show dynamic deadline text for tasks based on category
- compute deadline time in `TaskServiceImpl`
- store the computed text in new `Task.timeUntilDue`
- display it on the task page

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_686a81e598c4832a8f5790cb82648f4e