### PR TITLE
Handle null category in TaskServiceImpl

### DIFF
--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -36,24 +36,29 @@ public class TaskServiceImpl implements TaskService {
                 continue;
             }
             LocalDateTime deadline;
-            switch (t.getCategory()) {
-            case "今日":
+            String category = t.getCategory();
+            if (category == null) {
                 deadline = today.plusDays(1).atStartOfDay();
-                break;
-            case "明日":
-                deadline = today.plusDays(2).atStartOfDay();
-                break;
-            case "今週":
-                deadline = sundayThisWeek.plusDays(1).atStartOfDay();
-                break;
-            case "来週":
-                deadline = sundayThisWeek.plusWeeks(1).plusDays(1).atStartOfDay();
-                break;
-            case "再来週":
-                deadline = sundayThisWeek.plusWeeks(2).plusDays(1).atStartOfDay();
-                break;
-            default:
-                deadline = today.plusDays(1).atStartOfDay();
+            } else {
+                switch (category) {
+                case "今日":
+                    deadline = today.plusDays(1).atStartOfDay();
+                    break;
+                case "明日":
+                    deadline = today.plusDays(2).atStartOfDay();
+                    break;
+                case "今週":
+                    deadline = sundayThisWeek.plusDays(1).atStartOfDay();
+                    break;
+                case "来週":
+                    deadline = sundayThisWeek.plusWeeks(1).plusDays(1).atStartOfDay();
+                    break;
+                case "再来週":
+                    deadline = sundayThisWeek.plusWeeks(2).plusDays(1).atStartOfDay();
+                    break;
+                default:
+                    deadline = today.plusDays(1).atStartOfDay();
+                }
             }
             long minutes = Duration.between(now, deadline).toMinutes();
             if (minutes < 0)


### PR DESCRIPTION
## Summary
- prevent NullPointerException when a `Task` has no category

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686a84989970832aa362b175e88dfee8