### PR TITLE
Add delete button for tasks

### DIFF
--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -63,4 +63,19 @@ document.addEventListener('DOMContentLoaded', () => {
       sendUpdate(row);
     });
   });
+
+  document.querySelectorAll('.task-delete-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/task-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) })
+      }).then(() => {
+        row.remove();
+      });
+    });
+  });
 });

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -136,6 +136,7 @@
         <table class="task-database">
           <tr>
             <th>報告</th>
+            <th>削除</th>
             <th>タスク・疑問調査</th>
             <th>区分</th>
             <th>期日</th>
@@ -146,6 +147,7 @@
             </tr>
           <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
           <td><input type="button" value="完了" class="task-complete-button" /></td>
+          <td><input type="button" value="削除" class="task-delete-button" /></td>
           <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
             <td>
               <select class="task-category-select">


### PR DESCRIPTION
## Summary
- add a delete button for each task row
- handle delete actions in JavaScript

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a881e031c832a9e23b10746f2e36c