### PR TITLE
Add task box view with completed/incomplete lists

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -88,6 +88,26 @@ public class TopController {
         model.addAttribute("username", username);
         return "challenge-box";
     }
+
+    @GetMapping("/{username}/task-top/task-box")
+    public String showTaskBoxPage(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying task box page");
+        var all = taskService.getAllTasks();
+        var uncompleted = all.stream()
+                .filter(t -> t.getCompletedAt() == null)
+                .toList();
+        var completedTasks = all.stream()
+                .filter(t -> t.getCompletedAt() != null)
+                .toList();
+        model.addAttribute("uncompletedTasks", uncompleted);
+        model.addAttribute("completedTasks", completedTasks);
+        model.addAttribute("username", username);
+        return "task-box";
+    }
     //-------------------------------------------------------------------------------------------------
     @GetMapping("/total-point")
     @ResponseBody

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -10,6 +10,20 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const uncompletedTable = document.getElementById('uncompleted-task-table');
+  const completedTable = document.getElementById('completed-task-table');
+
+  function moveRow(row, completed) {
+    if (!row) return;
+    if (uncompletedTable && completedTable) {
+      const target = completed ? completedTable : uncompletedTable;
+      const tbody = target.tBodies[0] || target;
+      tbody.appendChild(row);
+    } else {
+      row.style.display = completed ? 'none' : '';
+    }
+  }
+
   function gatherData(row) {
     return {
       id: parseInt(row.dataset.id, 10),
@@ -90,18 +104,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const comp = row ? row.querySelector('.task-completed-input') : null;
     if (comp && comp.value) {
       btn.value = '取消';
-      if (row) row.style.display = 'none';
+      moveRow(row, true);
     }
     btn.addEventListener('click', () => {
       if (!row || !comp) return;
       if (btn.value === '完了') {
         comp.value = new Date().toISOString().split('T')[0];
         btn.value = '取消';
-        row.style.display = 'none';
+        moveRow(row, true);
       } else {
         comp.value = '';
         btn.value = '完了';
-        row.style.display = '';
+        moveRow(row, false);
       }
       sendUpdate(row);
     });

--- a/src/main/resources/templates/task-box.html
+++ b/src/main/resources/templates/task-box.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8" />
+<title>タスクボックス</title>
+<link rel="stylesheet" th:href="@{/css/style.css}" />
+</head>
+<body class="task-body">
+  <div class="link-area">
+    <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+  </div>
+
+  <div class="database-container">
+    <p>未完了タスク</p>
+    <table id="uncompleted-task-table" class="task-database">
+      <tr>
+        <th>報告</th>
+        <th>削除</th>
+        <th>タスク・疑問調査</th>
+        <th>区分</th>
+        <th>期日</th>
+        <th>結果</th>
+        <th>詳細</th>
+        <th>レベル</th>
+        <th>完了日</th>
+      </tr>
+      <tr th:each="task : ${uncompletedTasks}" class="task-row" th:data-id="${task.id}">
+        <td><input type="button" value="完了" class="task-complete-button" /></td>
+        <td><input type="button" value="削除" class="task-delete-button" /></td>
+        <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
+        <td>
+          <select class="task-category-select">
+            <option value="今日" th:selected="${task.category == '今日'}">今日</option>
+            <option value="明日" th:selected="${task.category == '明日'}">明日</option>
+            <option value="今週" th:selected="${task.category == '今週'}">今週</option>
+            <option value="来週" th:selected="${task.category == '来週'}">来週</option>
+            <option value="再来週" th:selected="${task.category == '再来週'}">再来週</option>
+          </select>
+        </td>
+        <td th:text="${task.timeUntilDue}"></td>
+        <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
+        <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>
+        <td>
+          <select class="task-level-select">
+            <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == task.level}"></option>
+          </select>
+        </td>
+        <td><input type="date" th:value="${task.completedAt}" class="task-completed-input" /></td>
+      </tr>
+    </table>
+    <button id="new-task-button">タスク新規</button>
+  </div>
+
+  <div class="database-container">
+    <p>完了済みタスク</p>
+    <table id="completed-task-table" class="task-database">
+      <tr>
+        <th>報告</th>
+        <th>削除</th>
+        <th>タスク・疑問調査</th>
+        <th>区分</th>
+        <th>期日</th>
+        <th>結果</th>
+        <th>詳細</th>
+        <th>レベル</th>
+        <th>完了日</th>
+      </tr>
+      <tr th:each="task : ${completedTasks}" class="task-row" th:data-id="${task.id}">
+        <td><input type="button" value="取消" class="task-complete-button" /></td>
+        <td><input type="button" value="削除" class="task-delete-button" /></td>
+        <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
+        <td>
+          <select class="task-category-select">
+            <option value="今日" th:selected="${task.category == '今日'}">今日</option>
+            <option value="明日" th:selected="${task.category == '明日'}">明日</option>
+            <option value="今週" th:selected="${task.category == '今週'}">今週</option>
+            <option value="来週" th:selected="${task.category == '来週'}">来週</option>
+            <option value="再来週" th:selected="${task.category == '再来週'}">再来週</option>
+          </select>
+        </td>
+        <td th:text="${task.timeUntilDue}"></td>
+        <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
+        <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>
+        <td>
+          <select class="task-level-select">
+            <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == task.level}"></option>
+          </select>
+        </td>
+        <td><input type="date" th:value="${task.completedAt}" class="task-completed-input" /></td>
+      </tr>
+    </table>
+  </div>
+
+  <script th:src="@{/js/task.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -9,7 +9,7 @@
     <body class="task-body">
       <div class="link-area">
         <a th:href="@{'/' + ${username} + '/task-top/challenge-box'}">挑戦ボックス</a>
-        <a href="@{'/' + ${username} + '/task-top/task-box'}">タスクボックス</a>
+        <a th:href="@{'/' + ${username} + '/task-top/task-box'}">タスクボックス</a>
         <a th:href="@{'/' + ${username} + '/task-top/schedule-box'}">予定ボックス</a>
         <!-- java変数などを埋め込める動的リンクを生成（Thymeleaf使用） @{URLパターン}，java側でusernameをmodel.addAttributeしてる-->
       </div>


### PR DESCRIPTION
## Summary
- add task-box template for viewing completed and unfinished tasks
- link from task-top page to new task box
- support moving rows between task tables in JavaScript
- expose new `/task-top/task-box` endpoint

## Testing
- `./mvnw -q test` *(fails: unable to resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a8c1b5964832a866229234e8c921c