### PR TITLE
Fix due date when completing tasks

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -71,8 +71,11 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void updateTask(Task task) {
-        String sql = "UPDATE tasks SET title = ?, category = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
-        java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
+        boolean completedFlag = task.getCompletedAt() != null;
+        String sql = "UPDATE tasks SET title = ?, category = ?, result = ?, detail = ?, level = ?, completed_at = ?, "
+                + (completedFlag ? "due_date = NULL, " : "")
+                + "updated_at = NOW() WHERE id = ?";
+        java.sql.Date completed = completedFlag ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
         jdbcTemplate.update(sql,
                 task.getTitle(),
                 task.getCategory(),


### PR DESCRIPTION
## Summary
- clear due_date column when a task is marked complete

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a8eaedfc4832abbbfbf338e73d3a9