### PR TITLE
Clear due date cell when completing a task

### DIFF
--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -112,10 +112,13 @@ document.addEventListener('DOMContentLoaded', () => {
         comp.value = new Date().toISOString().split('T')[0];
         btn.value = '取消';
         moveRow(row, true);
+        const cell = row.cells[4];
+        if (cell) cell.textContent = '';
       } else {
         comp.value = '';
         btn.value = '完了';
         moveRow(row, false);
+        updateTimeUntilDue(row);
       }
       sendUpdate(row);
     });


### PR DESCRIPTION
## Summary
- update task.js so the due date cell becomes blank upon completing a task
- recompute the due date when a task is marked incomplete

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686a906afea8832a94abb793652234cd