### PR TITLE
Include task levels in total points

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -115,6 +115,7 @@ public class TopController {
         log.debug("Fetching total completed points");
         int schedulePoints = scheduleService.getTotalCompletedPoints();
         int challengePoints = challengeService.getTotalCompletedPoints();
-        return schedulePoints + challengePoints;
+        int taskPoints = taskService.getTotalCompletedLevels();
+        return schedulePoints + challengePoints + taskPoints;
     }
 }

--- a/src/main/java/com/example/demo/repository/task/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepository.java
@@ -9,4 +9,5 @@ public interface TaskRepository {
     void insertTask(Task task);
     void updateTask(Task task);
     void deleteById(int id);
+    int sumCompletedLevels();
 }

--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -91,4 +91,11 @@ public class TaskRepositoryImpl implements TaskRepository {
         String sql = "DELETE FROM tasks WHERE id = ?";
         jdbcTemplate.update(sql, id);
     }
+
+    @Override
+    public int sumCompletedLevels() {
+        String sql = "SELECT COALESCE(SUM(level), 0) FROM tasks WHERE completed_at IS NOT NULL";
+        Integer result = jdbcTemplate.queryForObject(sql, Integer.class);
+        return result != null ? result : 0;
+    }
 }

--- a/src/main/java/com/example/demo/service/task/TaskService.java
+++ b/src/main/java/com/example/demo/service/task/TaskService.java
@@ -12,4 +12,6 @@ public interface TaskService {
     void updateTask(Task task);
 
     void deleteTaskById(int id);
+
+    int getTotalCompletedLevels();
 }

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -89,4 +89,10 @@ public class TaskServiceImpl implements TaskService {
         log.debug("Deleting task with id {}", id);
         repository.deleteById(id);
     }
+
+    @Override
+    public int getTotalCompletedLevels() {
+        log.debug("Fetching total completed task levels");
+        return repository.sumCompletedLevels();
+    }
 }

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -12,6 +12,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const uncompletedTable = document.getElementById('uncompleted-task-table');
   const completedTable = document.getElementById('completed-task-table');
+  const pointDisplay = document.getElementById('total-point-display');
+
+  function refreshTotalPoint() {
+    if (!pointDisplay) return;
+    fetch('/total-point')
+      .then((res) => res.json())
+      .then((pt) => {
+        pointDisplay.textContent = `${pt}P`;
+      });
+  }
 
   function moveRow(row, completed) {
     if (!row) return;
@@ -38,7 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function sendUpdate(row) {
     const data = gatherData(row);
-    fetch('/task-update', {
+    return fetch('/task-update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
@@ -92,7 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const row = inp.closest('tr');
         if (!row) return;
         if (selector === '.task-category-select') updateTimeUntilDue(row);
-        sendUpdate(row);
+        sendUpdate(row).then(refreshTotalPoint);
       };
       inp.addEventListener('change', handler);
       inp.addEventListener('input', handler);
@@ -120,7 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
         moveRow(row, false);
         updateTimeUntilDue(row);
       }
-      sendUpdate(row);
+      sendUpdate(row).then(refreshTotalPoint);
     });
   });
 
@@ -135,7 +145,10 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify({ id: parseInt(id, 10) })
       }).then(() => {
         row.remove();
+        refreshTotalPoint();
       });
     });
   });
+
+  refreshTotalPoint();
 });


### PR DESCRIPTION
## Summary
- track levels of completed tasks as points
- refresh the total point display when tasks change
- expose completed task level sum through the service and repository

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a935ea614832a8f1ec839b764e3a3