### PR TITLE
Display awareness records

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -13,6 +13,7 @@ import com.example.demo.entity.Schedule;
 import com.example.demo.service.challenge.ChallengeService;
 import com.example.demo.service.schedule.ScheduleService;
 import com.example.demo.service.task.TaskService;
+import com.example.demo.service.awareness.AwarenessRecordService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ public class TopController {
     private final ScheduleService scheduleService;
     private final ChallengeService challengeService;
     private final TaskService taskService;
+    private final AwarenessRecordService awarenessRecordService;
 
     @GetMapping("/{username}/task-top")
     public String showTaskTop(@PathVariable String username, Model model, HttpSession session) {
@@ -45,6 +47,8 @@ public class TopController {
                 .filter(t -> t.getCompletedAt() == null)
                 .toList();
         model.addAttribute("tasks", taskList);
+        var awarenessList = awarenessRecordService.getAllRecords();
+        model.addAttribute("awarenessRecords", awarenessList);
         model.addAttribute("username", username);
         return "task-top";
     }

--- a/src/main/java/com/example/demo/entity/AwarenessRecord.java
+++ b/src/main/java/com/example/demo/entity/AwarenessRecord.java
@@ -1,0 +1,11 @@
+package com.example.demo.entity;
+
+import lombok.Data;
+
+@Data
+public class AwarenessRecord {
+    private int id; // ID
+    private String awareness; // 気づき
+    private String opinion; // 意見
+    private int awarenessLevel; // 気づき度
+}

--- a/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepository.java
+++ b/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.repository.awareness;
+
+import java.util.List;
+
+import com.example.demo.entity.AwarenessRecord;
+
+public interface AwarenessRecordRepository {
+    List<AwarenessRecord> findAll();
+}

--- a/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.example.demo.repository.awareness;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.AwarenessRecord;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AwarenessRecordRepositoryImpl implements AwarenessRecordRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<AwarenessRecord> findAll() {
+        String sql = "SELECT id, awareness, opinion, awareness_level FROM awareness_records";
+        return jdbcTemplate.query(sql, new RowMapper<AwarenessRecord>() {
+            @Override
+            public AwarenessRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
+                AwarenessRecord r = new AwarenessRecord();
+                r.setId(rs.getInt("id"));
+                r.setAwareness(rs.getString("awareness"));
+                r.setOpinion(rs.getString("opinion"));
+                r.setAwarenessLevel(rs.getInt("awareness_level"));
+                return r;
+            }
+        });
+    }
+}

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordService.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordService.java
@@ -1,0 +1,9 @@
+package com.example.demo.service.awareness;
+
+import java.util.List;
+
+import com.example.demo.entity.AwarenessRecord;
+
+public interface AwarenessRecordService {
+    List<AwarenessRecord> getAllRecords();
+}

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.demo.service.awareness;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.AwarenessRecord;
+import com.example.demo.repository.awareness.AwarenessRecordRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AwarenessRecordServiceImpl implements AwarenessRecordService {
+
+    private final AwarenessRecordRepository repository;
+
+    @Override
+    public List<AwarenessRecord> getAllRecords() {
+        log.debug("Fetching all awareness records");
+        return repository.findAll();
+    }
+}

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -171,6 +171,21 @@
         </table>
       </div>
 
+      <div class="database-container">
+        <table class="awareness-database">
+          <tr>
+            <th>気づき</th>
+            <th>意見</th>
+            <th>気づき度</th>
+          </tr>
+          <tr th:each="record : ${awarenessRecords}">
+            <td th:text="${record.awareness}"></td>
+            <td th:text="${record.opinion}"></td>
+            <td th:text="${record.awarenessLevel}"></td>
+          </tr>
+        </table>
+      </div>
+
       <div id="schedule-overlay" class="schedule-overlay"></div>
       <!-- idはjs，classはcss用 -->
       <div id="schedule-popup" class="schedule-popup">


### PR DESCRIPTION
## Summary
- show awareness records on the task top page
- add AwarenessRecord entity, repository and service
- load awareness data in `TopController`

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a9ee24630832a9f7948d93acbf8ed