### PR TITLE
Enable user input for awareness records

### DIFF
--- a/src/main/java/com/example/demo/controller/AwarenessRecordController.java
+++ b/src/main/java/com/example/demo/controller/AwarenessRecordController.java
@@ -1,0 +1,41 @@
+package com.example.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.AwarenessRecord;
+import com.example.demo.service.awareness.AwarenessRecordService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class AwarenessRecordController {
+
+    private final AwarenessRecordService service;
+
+    @PostMapping("/awareness-add")
+    public ResponseEntity<Void> addRecord(@RequestBody AwarenessRecord record) {
+        log.debug("Adding awareness record");
+        service.addRecord(record);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/awareness-update")
+    public ResponseEntity<Void> updateRecord(@RequestBody AwarenessRecord record) {
+        log.debug("Updating awareness record id {}", record.getId());
+        service.updateRecord(record);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/awareness-delete")
+    public ResponseEntity<Void> deleteRecord(@RequestBody AwarenessRecord record) {
+        log.debug("Deleting awareness record id {}", record.getId());
+        service.deleteById(record.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepository.java
+++ b/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepository.java
@@ -6,4 +6,10 @@ import com.example.demo.entity.AwarenessRecord;
 
 public interface AwarenessRecordRepository {
     List<AwarenessRecord> findAll();
+
+    void insertRecord(AwarenessRecord record);
+
+    void updateRecord(AwarenessRecord record);
+
+    void deleteById(int id);
 }

--- a/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepositoryImpl.java
@@ -33,4 +33,29 @@ public class AwarenessRecordRepositoryImpl implements AwarenessRecordRepository 
             }
         });
     }
+
+    @Override
+    public void insertRecord(AwarenessRecord record) {
+        String sql = "INSERT INTO awareness_records (awareness, opinion, awareness_level) VALUES (?, ?, ?)";
+        jdbcTemplate.update(sql,
+                record.getAwareness(),
+                record.getOpinion(),
+                record.getAwarenessLevel());
+    }
+
+    @Override
+    public void updateRecord(AwarenessRecord record) {
+        String sql = "UPDATE awareness_records SET awareness = ?, opinion = ?, awareness_level = ? WHERE id = ?";
+        jdbcTemplate.update(sql,
+                record.getAwareness(),
+                record.getOpinion(),
+                record.getAwarenessLevel(),
+                record.getId());
+    }
+
+    @Override
+    public void deleteById(int id) {
+        String sql = "DELETE FROM awareness_records WHERE id = ?";
+        jdbcTemplate.update(sql, id);
+    }
 }

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordService.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordService.java
@@ -6,4 +6,10 @@ import com.example.demo.entity.AwarenessRecord;
 
 public interface AwarenessRecordService {
     List<AwarenessRecord> getAllRecords();
+
+    void addRecord(AwarenessRecord record);
+
+    void updateRecord(AwarenessRecord record);
+
+    void deleteById(int id);
 }

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
@@ -22,4 +22,22 @@ public class AwarenessRecordServiceImpl implements AwarenessRecordService {
         log.debug("Fetching all awareness records");
         return repository.findAll();
     }
+
+    @Override
+    public void addRecord(AwarenessRecord record) {
+        log.debug("Adding awareness record");
+        repository.insertRecord(record);
+    }
+
+    @Override
+    public void updateRecord(AwarenessRecord record) {
+        log.debug("Updating awareness record id {}", record.getId());
+        repository.updateRecord(record);
+    }
+
+    @Override
+    public void deleteById(int id) {
+        log.debug("Deleting awareness record id {}", id);
+        repository.deleteById(id);
+    }
 }

--- a/src/main/resources/static/js/awareness.js
+++ b/src/main/resources/static/js/awareness.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const newButton = document.getElementById('new-awareness-button');
+  if (newButton) {
+    newButton.addEventListener('click', () => {
+      fetch('/awareness-add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ awareness: '', opinion: '', awarenessLevel: 1 })
+      }).then(() => location.reload());
+    });
+  }
+
+  function gatherData(row) {
+    return {
+      id: parseInt(row.dataset.id, 10),
+      awareness: row.querySelector('.awareness-input').value,
+      opinion: row.querySelector('.opinion-input').value,
+      awarenessLevel: parseInt(row.querySelector('.awareness-level-select').value, 10)
+    };
+  }
+
+  function sendUpdate(row) {
+    const data = gatherData(row);
+    return fetch('/awareness-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+
+  document.querySelectorAll('.awareness-input, .opinion-input, .awareness-level-select').forEach((el) => {
+    el.addEventListener('change', () => {
+      const row = el.closest('tr');
+      if (row) sendUpdate(row);
+    });
+    el.addEventListener('input', () => {
+      const row = el.closest('tr');
+      if (row) sendUpdate(row);
+    });
+  });
+
+  document.querySelectorAll('.awareness-delete-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/awareness-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) })
+      }).then(() => row.remove());
+    });
+  });
+});

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -174,16 +174,23 @@
       <div class="database-container">
         <table class="awareness-database">
           <tr>
+            <th>削除</th>
             <th>気づき</th>
             <th>意見</th>
             <th>気づき度</th>
           </tr>
-          <tr th:each="record : ${awarenessRecords}">
-            <td th:text="${record.awareness}"></td>
-            <td th:text="${record.opinion}"></td>
-            <td th:text="${record.awarenessLevel}"></td>
+          <tr th:each="record : ${awarenessRecords}" th:data-id="${record.id}">
+            <td><input type="button" value="削除" class="awareness-delete-button" /></td>
+            <td><input type="text" th:value="${record.awareness}" class="awareness-input" /></td>
+            <td><input type="text" th:value="${record.opinion}" class="opinion-input" /></td>
+            <td>
+              <select class="awareness-level-select">
+                <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == record.awarenessLevel}"></option>
+              </select>
+            </td>
           </tr>
         </table>
+        <button id="new-awareness-button">新規</button>
       </div>
 
       <div id="schedule-overlay" class="schedule-overlay"></div>
@@ -198,6 +205,7 @@
       <script th:src="@{/js/challenge.js}"></script>
       <script th:src="@{/js/schedule.js}"></script>
       <script th:src="@{/js/task.js}"></script>
+      <script th:src="@{/js/awareness.js}"></script>
       <script th:src="@{/js/calendar-detail.js}"></script>
     </body>
   </html>


### PR DESCRIPTION
## Summary
- allow CRUD operations on awareness records
- add awareness record controller and service methods
- provide insert/update/delete queries for awareness records
- add awareness.js to manage UI interactions
- update task-top.html to show editable table and new record button

## Testing
- `./mvnw -q test` *(fails: could not resolve parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686aa1802114832a9aa596ae62c53a61