### PR TITLE
Add awareness button to top page

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -68,6 +68,12 @@ body.task-body {
   left: 50px;
 }
 
+#new-awareness-button {
+  position: fixed;
+  top: 400px;
+  left: 50px;
+}
+
 /* task-top.html だけの処理*/
 
 .calendar-area {

--- a/src/main/resources/static/js/awareness.js
+++ b/src/main/resources/static/js/awareness.js
@@ -1,14 +1,13 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const newButton = document.getElementById('new-awareness-button');
-  if (newButton) {
-    newButton.addEventListener('click', () => {
+  document.querySelectorAll('#new-awareness-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
       fetch('/awareness-add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ awareness: '', opinion: '', awarenessLevel: 1 })
       }).then(() => location.reload());
     });
-  }
+  });
 
   function gatherData(row) {
     return {

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -95,6 +95,7 @@
         <div id="total-point-display"></div>
         <button id="new-challenge-button">挑戦新規</button>
         <button id="new-task-button">タスク新規</button>
+        <button id="new-awareness-button">新規気づき</button>
       </div>
 
       <div class="database-container">


### PR DESCRIPTION
## Summary
- add `新規気づき` button below the new task button
- style the new awareness button
- allow multiple awareness buttons in JS

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686aa558be58832a9d1e0969f1ff9d32