### PR TITLE
Add awareness box page

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -112,6 +112,19 @@ public class TopController {
         model.addAttribute("username", username);
         return "task-box";
     }
+
+    @GetMapping("/{username}/task-top/awareness-box")
+    public String showAwarenessBox(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying awareness box page");
+        var records = awarenessRecordService.getAllRecords();
+        model.addAttribute("awarenessRecords", records);
+        model.addAttribute("username", username);
+        return "awareness-box";
+    }
     //-------------------------------------------------------------------------------------------------
     @GetMapping("/total-point")
     @ResponseBody

--- a/src/main/resources/templates/awareness-box.html
+++ b/src/main/resources/templates/awareness-box.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>気づきボックス</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+    </div>
+
+    <div class="database-container">
+      <table class="awareness-database">
+        <tr>
+          <th>削除</th>
+          <th>気づき</th>
+          <th>意見</th>
+          <th>気づき度</th>
+        </tr>
+        <tr th:each="record : ${awarenessRecords}" th:data-id="${record.id}">
+          <td><input type="button" value="削除" class="awareness-delete-button" /></td>
+          <td><input type="text" th:value="${record.awareness}" class="awareness-input" /></td>
+          <td><input type="text" th:value="${record.opinion}" class="opinion-input" /></td>
+          <td>
+            <select class="awareness-level-select">
+              <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == record.awarenessLevel}"></option>
+            </select>
+          </td>
+        </tr>
+      </table>
+      <button id="new-awareness-button">新規気づき</button>
+    </div>
+
+    <script th:src="@{/js/awareness.js}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement an "awareness-box" page displaying awareness records
- add endpoint in `TopController` to serve the new page

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686aa8918138832a98cc788432708885