### PR TITLE
Add awareness level points to total score

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -128,11 +128,12 @@ public class TopController {
     //-------------------------------------------------------------------------------------------------
     @GetMapping("/total-point")
     @ResponseBody
-    public Integer getTotalPoint() {
+    public Double getTotalPoint() {
         log.debug("Fetching total completed points");
         int schedulePoints = scheduleService.getTotalCompletedPoints();
         int challengePoints = challengeService.getTotalCompletedPoints();
         int taskPoints = taskService.getTotalCompletedLevels();
-        return schedulePoints + challengePoints + taskPoints;
+        int awareness = awarenessRecordService.getTotalAwarenessLevel();
+        return schedulePoints + challengePoints + taskPoints + awareness * 0.5;
     }
 }

--- a/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepository.java
+++ b/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepository.java
@@ -12,4 +12,6 @@ public interface AwarenessRecordRepository {
     void updateRecord(AwarenessRecord record);
 
     void deleteById(int id);
+
+    int sumAwarenessLevels();
 }

--- a/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepositoryImpl.java
@@ -58,4 +58,11 @@ public class AwarenessRecordRepositoryImpl implements AwarenessRecordRepository 
         String sql = "DELETE FROM awareness_records WHERE id = ?";
         jdbcTemplate.update(sql, id);
     }
+
+    @Override
+    public int sumAwarenessLevels() {
+        String sql = "SELECT COALESCE(SUM(awareness_level), 0) FROM awareness_records";
+        Integer result = jdbcTemplate.queryForObject(sql, Integer.class);
+        return result != null ? result : 0;
+    }
 }

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordService.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordService.java
@@ -12,4 +12,6 @@ public interface AwarenessRecordService {
     void updateRecord(AwarenessRecord record);
 
     void deleteById(int id);
+
+    int getTotalAwarenessLevel();
 }

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
@@ -40,4 +40,10 @@ public class AwarenessRecordServiceImpl implements AwarenessRecordService {
         log.debug("Deleting awareness record id {}", id);
         repository.deleteById(id);
     }
+
+    @Override
+    public int getTotalAwarenessLevel() {
+        log.debug("Fetching total awareness levels");
+        return repository.sumAwarenessLevels();
+    }
 }


### PR DESCRIPTION
## Summary
- sum awareness record levels via repository/service
- include awareness contribution in total points API

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686aab27f0c4832a934f33ed09d26b3c