### PR TITLE
Update awareness.js to refresh total points

### DIFF
--- a/src/main/resources/static/js/awareness.js
+++ b/src/main/resources/static/js/awareness.js
@@ -9,6 +9,19 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  const pointDisplay = document.getElementById('total-point-display');
+
+  function refreshTotalPoint() {
+    if (!pointDisplay) return;
+    fetch('/total-point')
+      .then((res) => res.json())
+      .then((pt) => {
+        pointDisplay.textContent = `${pt}P`;
+      });
+  }
+
+  refreshTotalPoint();
+
   function gatherData(row) {
     return {
       id: parseInt(row.dataset.id, 10),
@@ -24,6 +37,8 @@ document.addEventListener('DOMContentLoaded', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
+    }).then(() => {
+      refreshTotalPoint();
     });
   }
 
@@ -47,7 +62,10 @@ document.addEventListener('DOMContentLoaded', () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: parseInt(id, 10) })
-      }).then(() => row.remove());
+      }).then(() => {
+        row.remove();
+        refreshTotalPoint();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- update awareness.js to fetch total points when awareness record changes
- show updated points when awareness records are deleted

## Testing
- `mvn -q test` *(fails: Could not transfer artifact due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686aac725208832abab86d91a131bec7