### PR TITLE
Sort tasks by due date

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -22,7 +22,8 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public List<Task> findAll() {
-        String sql = "SELECT id, title, category, due_date, result, detail, level, created_at, updated_at, completed_at FROM tasks";
+        String sql = "SELECT id, title, category, due_date, result, detail, level, created_at, updated_at, completed_at "
+                + "FROM tasks ORDER BY due_date ASC";
         return jdbcTemplate.query(sql, new RowMapper<Task>() {
             @Override
             public Task mapRow(ResultSet rs, int rowNum) throws SQLException {


### PR DESCRIPTION
## Summary
- sort tasks in ascending order by `due_date` in the database query

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network access)*

------
https://chatgpt.com/codex/tasks/task_e_686aaf2afd6c832a8ade259f4f745463