### PR TITLE
Sort tasks by category

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -23,7 +23,13 @@ public class TaskRepositoryImpl implements TaskRepository {
     @Override
     public List<Task> findAll() {
         String sql = "SELECT id, title, category, due_date, result, detail, level, created_at, updated_at, completed_at "
-                + "FROM tasks ORDER BY due_date ASC";
+                + "FROM tasks ORDER BY CASE category "
+                + "WHEN '今日' THEN 1 "
+                + "WHEN '明日' THEN 2 "
+                + "WHEN '今週' THEN 3 "
+                + "WHEN '来週' THEN 4 "
+                + "WHEN '再来週' THEN 5 "
+                + "ELSE 6 END";
         return jdbcTemplate.query(sql, new RowMapper<Task>() {
             @Override
             public Task mapRow(ResultSet rs, int rowNum) throws SQLException {


### PR DESCRIPTION
## Summary
- order tasks by category in preferred sequence instead of due date

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ab2136e74832a9d1e37e61f659436