### PR TITLE
Limit awareness list to five

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -47,7 +47,10 @@ public class TopController {
                 .filter(t -> t.getCompletedAt() == null)
                 .toList();
         model.addAttribute("tasks", taskList);
-        var awarenessList = awarenessRecordService.getAllRecords();
+        var awarenessList = awarenessRecordService.getAllRecords()
+                .stream()
+                .limit(5)
+                .toList();
         model.addAttribute("awarenessRecords", awarenessList);
         model.addAttribute("username", username);
         return "task-top";


### PR DESCRIPTION
## Summary
- show only five awareness records on the task top page

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686abce2218c832a9cfc29a65f1de48c