### PR TITLE
Fix awareness deletion

### DIFF
--- a/src/main/resources/static/js/awareness.js
+++ b/src/main/resources/static/js/awareness.js
@@ -63,8 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: parseInt(id, 10) })
       }).then(() => {
-        row.remove();
-        refreshTotalPoint();
+        location.reload();
       });
     });
   });


### PR DESCRIPTION
## Summary
- update `awareness.js` to reload the page after deleting an awareness record

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686bad306eac832aa7c0fe84909c2632