### PR TITLE
Fix challenge date edits

### DIFF
--- a/src/main/resources/static/js/challenge.js
+++ b/src/main/resources/static/js/challenge.js
@@ -138,7 +138,15 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   //--------------------------------------------------------------------------------------
-  ['.challenge-title-input', '.challenge-risk-input', '.challenge-expected-input', '.challenge-strategy-input', '.challenge-actual-input', '.challenge-improvement-input'].forEach((selector) => {
+  [
+    '.challenge-title-input',
+    '.challenge-risk-input',
+    '.challenge-expected-input',
+    '.challenge-strategy-input',
+    '.challenge-actual-input',
+    '.challenge-improvement-input',
+    '.challenge-date-input',
+  ].forEach((selector) => {
     document.querySelectorAll(selector).forEach((inp) => {
       const handler = () => {
         const row = inp.closest('tr');


### PR DESCRIPTION
## Summary
- persist edits to challenge date by listening to change events

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686bb9fe17ec832aab1910131d0f6267