### PR TITLE
Hide text until selection

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -293,3 +293,17 @@ td {
 .review-list {
   background-color: #afeeee;
 }
+
+/* Hide text in challenge, task, and awareness databases until selected */
+.chalenge-database input[type="text"],
+.task-database input[type="text"],
+.awareness-database input[type="text"] {
+  color: transparent;
+  caret-color: black;
+}
+
+.chalenge-database input[type="text"]::selection,
+.task-database input[type="text"]::selection,
+.awareness-database input[type="text"]::selection {
+  color: black;
+}


### PR DESCRIPTION
## Summary
- hide text in challenge, task, and awareness databases until selected with the mouse

## Testing
- `mvn test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686bbeae145c832a80a7760cc796237b