### PR TITLE
Add diary page feature for awareness records

### DIFF
--- a/src/main/java/com/example/demo/controller/AwarenessPageController.java
+++ b/src/main/java/com/example/demo/controller/AwarenessPageController.java
@@ -1,0 +1,46 @@
+package com.example.demo.controller;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.AwarenessPage;
+import com.example.demo.service.page.AwarenessPageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class AwarenessPageController {
+
+    private final AwarenessPageService service;
+
+    @GetMapping("/{username}/task-top/awareness-page/{recordId}")
+    public String showAwarenessPage(@PathVariable String username, @PathVariable int recordId,
+            Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying awareness page for record {}", recordId);
+        AwarenessPage page = service.getOrCreatePage(recordId);
+        model.addAttribute("page", page);
+        model.addAttribute("username", username);
+        return "awareness-page";
+    }
+
+    @PostMapping("/awareness-page-update")
+    public ResponseEntity<Void> updateAwarenessPage(@RequestBody AwarenessPage page) {
+        log.debug("Updating awareness page id {}", page.getId());
+        service.updatePage(page);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/entity/AwarenessPage.java
+++ b/src/main/java/com/example/demo/entity/AwarenessPage.java
@@ -1,0 +1,10 @@
+package com.example.demo.entity;
+
+import lombok.Data;
+
+@Data
+public class AwarenessPage {
+    private int id; // 自動採番ID
+    private int recordId; // 対応する気づきレコードID
+    private String content; // 日記内容
+}

--- a/src/main/java/com/example/demo/repository/page/AwarenessPageRepository.java
+++ b/src/main/java/com/example/demo/repository/page/AwarenessPageRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository.page;
+
+import com.example.demo.entity.AwarenessPage;
+
+public interface AwarenessPageRepository {
+    AwarenessPage findByRecordId(int recordId);
+
+    void insertPage(AwarenessPage page);
+
+    void updatePage(AwarenessPage page);
+}

--- a/src/main/java/com/example/demo/repository/page/AwarenessPageRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/page/AwarenessPageRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.example.demo.repository.page;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.AwarenessPage;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AwarenessPageRepositoryImpl implements AwarenessPageRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public AwarenessPage findByRecordId(int recordId) {
+        String sql = "SELECT id, record_id, content FROM awareness_pages WHERE record_id = ?";
+        List<AwarenessPage> list = jdbcTemplate.query(sql, new RowMapper<AwarenessPage>() {
+            @Override
+            public AwarenessPage mapRow(ResultSet rs, int rowNum) throws SQLException {
+                AwarenessPage p = new AwarenessPage();
+                p.setId(rs.getInt("id"));
+                p.setRecordId(rs.getInt("record_id"));
+                p.setContent(rs.getString("content"));
+                return p;
+            }
+        }, recordId);
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    @Override
+    public void insertPage(AwarenessPage page) {
+        String sql = "INSERT INTO awareness_pages (record_id, content) VALUES (?, ?)";
+        jdbcTemplate.update(sql, page.getRecordId(), page.getContent());
+    }
+
+    @Override
+    public void updatePage(AwarenessPage page) {
+        String sql = "UPDATE awareness_pages SET content = ? WHERE id = ?";
+        jdbcTemplate.update(sql, page.getContent(), page.getId());
+    }
+}

--- a/src/main/java/com/example/demo/service/page/AwarenessPageService.java
+++ b/src/main/java/com/example/demo/service/page/AwarenessPageService.java
@@ -1,0 +1,8 @@
+package com.example.demo.service.page;
+
+import com.example.demo.entity.AwarenessPage;
+
+public interface AwarenessPageService {
+    AwarenessPage getOrCreatePage(int recordId);
+    void updatePage(AwarenessPage page);
+}

--- a/src/main/java/com/example/demo/service/page/AwarenessPageServiceImpl.java
+++ b/src/main/java/com/example/demo/service/page/AwarenessPageServiceImpl.java
@@ -1,0 +1,37 @@
+package com.example.demo.service.page;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.AwarenessPage;
+import com.example.demo.repository.page.AwarenessPageRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AwarenessPageServiceImpl implements AwarenessPageService {
+
+    private final AwarenessPageRepository repository;
+
+    @Override
+    public AwarenessPage getOrCreatePage(int recordId) {
+        log.debug("Fetching page for record {}", recordId);
+        AwarenessPage p = repository.findByRecordId(recordId);
+        if (p == null) {
+            p = new AwarenessPage();
+            p.setRecordId(recordId);
+            p.setContent("");
+            repository.insertPage(p);
+            p = repository.findByRecordId(recordId);
+        }
+        return p;
+    }
+
+    @Override
+    public void updatePage(AwarenessPage page) {
+        log.debug("Updating page id {}", page.getId());
+        repository.updatePage(page);
+    }
+}

--- a/src/main/resources/static/js/awareness-page.js
+++ b/src/main/resources/static/js/awareness-page.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const textarea = document.getElementById('awareness-page-content');
+  if (!textarea) return;
+  const save = () => {
+    fetch('/awareness-page-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: pageId, content: textarea.value })
+    });
+  };
+  textarea.addEventListener('change', save);
+  textarea.addEventListener('input', save);
+});

--- a/src/main/resources/templates/awareness-box.html
+++ b/src/main/resources/templates/awareness-box.html
@@ -14,12 +14,14 @@
       <table class="awareness-database">
         <tr>
           <th>削除</th>
+          <th>ページ</th>
           <th>気づき</th>
           <th>意見</th>
           <th>気づき度</th>
         </tr>
         <tr th:each="record : ${awarenessRecords}" th:data-id="${record.id}">
           <td><input type="button" value="削除" class="awareness-delete-button" /></td>
+          <td><a th:href="@{'/' + ${username} + '/task-top/awareness-page/' + ${record.id}}">ページ</a></td>
           <td><input type="text" th:value="${record.awareness}" class="awareness-input" /></td>
           <td><input type="text" th:value="${record.opinion}" class="opinion-input" /></td>
           <td>

--- a/src/main/resources/templates/awareness-page.html
+++ b/src/main/resources/templates/awareness-page.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>気づきページ</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top/awareness-box'}">一覧へ戻る</a>
+    </div>
+
+    <div class="page-container">
+      <textarea id="awareness-page-content" rows="20" cols="80" th:text="${page.content}"></textarea>
+    </div>
+
+    <script th:src="@{/js/awareness-page.js}"></script>
+    <script th:inline="javascript">
+      const pageId = [[${page.id}]];
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `AwarenessPage` entity and persistence layer
- create `AwarenessPageService` with controller endpoints
- add `awareness-page.html` template and JavaScript for auto saving
- link new page from the awareness database list

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686bc4761eb0832a9e38d757151bb259