### PR TITLE
Fix FK delete issue for awareness pages

### DIFF
--- a/src/main/java/com/example/demo/repository/page/AwarenessPageRepository.java
+++ b/src/main/java/com/example/demo/repository/page/AwarenessPageRepository.java
@@ -8,4 +8,6 @@ public interface AwarenessPageRepository {
     void insertPage(AwarenessPage page);
 
     void updatePage(AwarenessPage page);
+
+    void deleteByRecordId(int recordId);
 }

--- a/src/main/java/com/example/demo/repository/page/AwarenessPageRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/page/AwarenessPageRepositoryImpl.java
@@ -45,4 +45,10 @@ public class AwarenessPageRepositoryImpl implements AwarenessPageRepository {
         String sql = "UPDATE awareness_pages SET content = ? WHERE id = ?";
         jdbcTemplate.update(sql, page.getContent(), page.getId());
     }
+
+    @Override
+    public void deleteByRecordId(int recordId) {
+        String sql = "DELETE FROM awareness_pages WHERE record_id = ?";
+        jdbcTemplate.update(sql, recordId);
+    }
 }

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.example.demo.entity.AwarenessRecord;
 import com.example.demo.repository.awareness.AwarenessRecordRepository;
+import com.example.demo.service.page.AwarenessPageService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AwarenessRecordServiceImpl implements AwarenessRecordService {
 
     private final AwarenessRecordRepository repository;
+    private final AwarenessPageService pageService;
 
     @Override
     public List<AwarenessRecord> getAllRecords() {
@@ -38,6 +40,7 @@ public class AwarenessRecordServiceImpl implements AwarenessRecordService {
     @Override
     public void deleteById(int id) {
         log.debug("Deleting awareness record id {}", id);
+        pageService.deleteByRecordId(id);
         repository.deleteById(id);
     }
 

--- a/src/main/java/com/example/demo/service/page/AwarenessPageService.java
+++ b/src/main/java/com/example/demo/service/page/AwarenessPageService.java
@@ -5,4 +5,5 @@ import com.example.demo.entity.AwarenessPage;
 public interface AwarenessPageService {
     AwarenessPage getOrCreatePage(int recordId);
     void updatePage(AwarenessPage page);
+    void deleteByRecordId(int recordId);
 }

--- a/src/main/java/com/example/demo/service/page/AwarenessPageServiceImpl.java
+++ b/src/main/java/com/example/demo/service/page/AwarenessPageServiceImpl.java
@@ -34,4 +34,10 @@ public class AwarenessPageServiceImpl implements AwarenessPageService {
         log.debug("Updating page id {}", page.getId());
         repository.updatePage(page);
     }
+
+    @Override
+    public void deleteByRecordId(int recordId) {
+        log.debug("Deleting page for record {}", recordId);
+        repository.deleteByRecordId(recordId);
+    }
 }


### PR DESCRIPTION
## Summary
- allow deleting awareness pages by record ID
- remove awareness pages before deleting records

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686bf0eabf2c832aaad2a2b6955d85fc