### PR TITLE
Add link to awareness page on top screen

### DIFF
--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -177,12 +177,14 @@
         <table class="awareness-database">
           <tr>
             <th>削除</th>
+            <th>ページ</th>
             <th>気づき</th>
             <th>意見</th>
             <th>気づき度</th>
           </tr>
           <tr th:each="record : ${awarenessRecords}" th:data-id="${record.id}">
             <td><input type="button" value="削除" class="awareness-delete-button" /></td>
+            <td><a th:href="@{'/' + ${username} + '/task-top/awareness-page/' + ${record.id}}">ページ</a></td>
             <td><input type="text" th:value="${record.awareness}" class="awareness-input" /></td>
             <td><input type="text" th:value="${record.opinion}" class="opinion-input" /></td>
             <td>


### PR DESCRIPTION
## Summary
- expose a new Page column in `task-top.html`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686bf3d988c0832ab163e5e585f34bbb