### PR TITLE
Auto adjust task category based on due time

### DIFF
--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -45,6 +45,14 @@ public class TaskServiceImpl implements TaskService {
                     deadline = today.plusDays(1).atStartOfDay();
                     break;
                 case "明日":
+                    LocalDateTime startOfTomorrow = today.plusDays(1).atStartOfDay();
+                    if (now.isAfter(startOfTomorrow)) {
+                        t.setCategory("今日");
+                        repository.updateTask(t);
+                        category = "今日";
+                        deadline = today.plusDays(1).atStartOfDay();
+                        break;
+                    }
                     deadline = today.plusDays(2).atStartOfDay();
                     break;
                 case "今週":


### PR DESCRIPTION
## Summary
- update `TaskServiceImpl` so tasks set to `明日` automatically move to `今日` when less than 24 hours remain

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d0262df48832a9a85d39ef2149376