### PR TITLE
Show awareness text on page

### DIFF
--- a/src/main/java/com/example/demo/controller/AwarenessPageController.java
+++ b/src/main/java/com/example/demo/controller/AwarenessPageController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.example.demo.entity.AwarenessPage;
+import com.example.demo.entity.AwarenessRecord;
 import com.example.demo.service.page.AwarenessPageService;
+import com.example.demo.service.awareness.AwarenessRecordService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AwarenessPageController {
 
     private final AwarenessPageService service;
+    private final AwarenessRecordService recordService;
 
     @GetMapping("/{username}/task-top/awareness-page/{recordId}")
     public String showAwarenessPage(@PathVariable String username, @PathVariable int recordId,
@@ -32,7 +35,12 @@ public class AwarenessPageController {
         }
         log.debug("Displaying awareness page for record {}", recordId);
         AwarenessPage page = service.getOrCreatePage(recordId);
+        AwarenessRecord record = recordService.getAllRecords().stream()
+                .filter(r -> r.getId() == recordId)
+                .findFirst()
+                .orElse(null);
         model.addAttribute("page", page);
+        model.addAttribute("record", record);
         model.addAttribute("username", username);
         return "awareness-page";
     }

--- a/src/main/resources/templates/awareness-page.html
+++ b/src/main/resources/templates/awareness-page.html
@@ -10,6 +10,10 @@
       <a th:href="@{'/' + ${username} + '/task-top/awareness-box'}">一覧へ戻る</a>
     </div>
 
+    <div class="awareness-title">
+      <span th:text="${record != null ? record.awareness : ''}"></span>
+    </div>
+
     <div class="page-container">
       <textarea id="awareness-page-content" rows="20" cols="80" th:text="${page.content}"></textarea>
     </div>


### PR DESCRIPTION
## Summary
- show the awareness record for each awareness page
- display the awareness text on the awareness page screen

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d132bf9f4832a87a01fe4cf8227ee