### PR TITLE
Add task pages

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskPageController.java
+++ b/src/main/java/com/example/demo/controller/TaskPageController.java
@@ -1,0 +1,54 @@
+package com.example.demo.controller;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.Task;
+import com.example.demo.entity.TaskPage;
+import com.example.demo.service.page.TaskPageService;
+import com.example.demo.service.task.TaskService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class TaskPageController {
+
+    private final TaskPageService service;
+    private final TaskService taskService;
+
+    @GetMapping("/{username}/task-top/task-page/{taskId}")
+    public String showTaskPage(@PathVariable String username, @PathVariable int taskId,
+            Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying task page for task {}", taskId);
+        TaskPage page = service.getOrCreatePage(taskId);
+        Task task = taskService.getAllTasks().stream()
+                .filter(t -> t.getId() == taskId)
+                .findFirst()
+                .orElse(null);
+        model.addAttribute("page", page);
+        model.addAttribute("task", task);
+        model.addAttribute("username", username);
+        return "task-page";
+    }
+
+    @PostMapping("/task-page-update")
+    public ResponseEntity<Void> updateTaskPage(@RequestBody TaskPage page) {
+        log.debug("Updating task page id {}", page.getId());
+        service.updatePage(page);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/entity/TaskPage.java
+++ b/src/main/java/com/example/demo/entity/TaskPage.java
@@ -1,0 +1,10 @@
+package com.example.demo.entity;
+
+import lombok.Data;
+
+@Data
+public class TaskPage {
+    private int id; // 自動採番ID
+    private int taskId; // 対応するタスクID
+    private String content; // ページ内容
+}

--- a/src/main/java/com/example/demo/repository/page/TaskPageRepository.java
+++ b/src/main/java/com/example/demo/repository/page/TaskPageRepository.java
@@ -1,0 +1,13 @@
+package com.example.demo.repository.page;
+
+import com.example.demo.entity.TaskPage;
+
+public interface TaskPageRepository {
+    TaskPage findByTaskId(int taskId);
+
+    void insertPage(TaskPage page);
+
+    void updatePage(TaskPage page);
+
+    void deleteByTaskId(int taskId);
+}

--- a/src/main/java/com/example/demo/repository/page/TaskPageRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/page/TaskPageRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.example.demo.repository.page;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.TaskPage;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TaskPageRepositoryImpl implements TaskPageRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public TaskPage findByTaskId(int taskId) {
+        String sql = "SELECT id, task_id, content FROM task_pages WHERE task_id = ?";
+        List<TaskPage> list = jdbcTemplate.query(sql, new RowMapper<TaskPage>() {
+            @Override
+            public TaskPage mapRow(ResultSet rs, int rowNum) throws SQLException {
+                TaskPage p = new TaskPage();
+                p.setId(rs.getInt("id"));
+                p.setTaskId(rs.getInt("task_id"));
+                p.setContent(rs.getString("content"));
+                return p;
+            }
+        }, taskId);
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    @Override
+    public void insertPage(TaskPage page) {
+        String sql = "INSERT INTO task_pages (task_id, content) VALUES (?, ?)";
+        jdbcTemplate.update(sql, page.getTaskId(), page.getContent());
+    }
+
+    @Override
+    public void updatePage(TaskPage page) {
+        String sql = "UPDATE task_pages SET content = ? WHERE id = ?";
+        jdbcTemplate.update(sql, page.getContent(), page.getId());
+    }
+
+    @Override
+    public void deleteByTaskId(int taskId) {
+        String sql = "DELETE FROM task_pages WHERE task_id = ?";
+        jdbcTemplate.update(sql, taskId);
+    }
+}

--- a/src/main/java/com/example/demo/service/page/TaskPageService.java
+++ b/src/main/java/com/example/demo/service/page/TaskPageService.java
@@ -1,0 +1,9 @@
+package com.example.demo.service.page;
+
+import com.example.demo.entity.TaskPage;
+
+public interface TaskPageService {
+    TaskPage getOrCreatePage(int taskId);
+    void updatePage(TaskPage page);
+    void deleteByTaskId(int taskId);
+}

--- a/src/main/java/com/example/demo/service/page/TaskPageServiceImpl.java
+++ b/src/main/java/com/example/demo/service/page/TaskPageServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.demo.service.page;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.TaskPage;
+import com.example.demo.repository.page.TaskPageRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TaskPageServiceImpl implements TaskPageService {
+
+    private final TaskPageRepository repository;
+
+    @Override
+    public TaskPage getOrCreatePage(int taskId) {
+        log.debug("Fetching task page for task {}", taskId);
+        TaskPage p = repository.findByTaskId(taskId);
+        if (p == null) {
+            p = new TaskPage();
+            p.setTaskId(taskId);
+            p.setContent("");
+            repository.insertPage(p);
+            p = repository.findByTaskId(taskId);
+        }
+        return p;
+    }
+
+    @Override
+    public void updatePage(TaskPage page) {
+        log.debug("Updating task page id {}", page.getId());
+        repository.updatePage(page);
+    }
+
+    @Override
+    public void deleteByTaskId(int taskId) {
+        log.debug("Deleting task page for task {}", taskId);
+        repository.deleteByTaskId(taskId);
+    }
+}

--- a/src/main/resources/static/js/task-page.js
+++ b/src/main/resources/static/js/task-page.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const textarea = document.getElementById('task-page-content');
+  if (!textarea) return;
+  const save = () => {
+    fetch('/task-page-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: pageId, content: textarea.value })
+    });
+  };
+  textarea.addEventListener('change', save);
+  textarea.addEventListener('input', save);
+});

--- a/src/main/resources/templates/task-box.html
+++ b/src/main/resources/templates/task-box.html
@@ -16,6 +16,7 @@
       <tr>
         <th>報告</th>
         <th>削除</th>
+        <th>ページ</th>
         <th>タスク・疑問調査</th>
         <th>区分</th>
         <th>期日</th>
@@ -27,6 +28,7 @@
       <tr th:each="task : ${uncompletedTasks}" class="task-row" th:data-id="${task.id}">
         <td><input type="button" value="完了" class="task-complete-button" /></td>
         <td><input type="button" value="削除" class="task-delete-button" /></td>
+        <td><a th:href="@{'/' + ${username} + '/task-top/task-page/' + ${task.id}}">ページ</a></td>
         <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
         <td>
           <select class="task-category-select">
@@ -57,6 +59,7 @@
       <tr>
         <th>報告</th>
         <th>削除</th>
+        <th>ページ</th>
         <th>タスク・疑問調査</th>
         <th>区分</th>
         <th>期日</th>
@@ -68,6 +71,7 @@
       <tr th:each="task : ${completedTasks}" class="task-row" th:data-id="${task.id}">
         <td><input type="button" value="取消" class="task-complete-button" /></td>
         <td><input type="button" value="削除" class="task-delete-button" /></td>
+        <td><a th:href="@{'/' + ${username} + '/task-top/task-page/' + ${task.id}}">ページ</a></td>
         <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
         <td>
           <select class="task-category-select">

--- a/src/main/resources/templates/task-page.html
+++ b/src/main/resources/templates/task-page.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>タスクページ</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top/task-box'}">一覧へ戻る</a>
+    </div>
+
+    <div class="awareness-title">
+      <span th:text="${task != null ? task.title : ''}"></span>
+    </div>
+
+    <div class="page-container">
+      <textarea id="task-page-content" rows="20" cols="80" th:text="${page.content}"></textarea>
+    </div>
+
+    <script th:src="@{/js/task-page.js}"></script>
+    <script th:inline="javascript">
+      const pageId = [[${page.id}]];
+    </script>
+  </body>
+</html>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -139,6 +139,7 @@
           <tr>
             <th>報告</th>
             <th>削除</th>
+            <th>ページ</th>
             <th>タスク・疑問調査</th>
             <th>区分</th>
             <th>期日</th>
@@ -150,6 +151,7 @@
           <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
           <td><input type="button" value="完了" class="task-complete-button" /></td>
           <td><input type="button" value="削除" class="task-delete-button" /></td>
+          <td><a th:href="@{'/' + ${username} + '/task-top/task-page/' + ${task.id}}">ページ</a></td>
           <td><input type="text" th:value="${task.title}" class="task-title-input" /></td>
             <td>
               <select class="task-category-select">


### PR DESCRIPTION
## Summary
- support per-task page content
- add repository/service/controller for TaskPage
- expose `/task-top/task-page/{taskId}` page for editing
- link task page from task lists in task-top and task-box

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686d15be8d90832a8e626afb71bcfc4c