### PR TITLE
Fix task category persistence

### DIFF
--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -5,7 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch('/task-add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: '', category: '今日', result: '', detail: '', level: 1 })
+        body: JSON.stringify({ title: '', category: '今日', result: '', detail: '', level: 1 }),
+        keepalive: true
       }).then(() => location.reload());
     });
   }
@@ -51,7 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
     return fetch('/task-update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
+      keepalive: true
     });
   }
 
@@ -164,7 +166,8 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch('/task-delete', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: parseInt(id, 10) })
+        body: JSON.stringify({ id: parseInt(id, 10) }),
+        keepalive: true
       }).then(() => {
         row.remove();
         refreshTotalPoint();


### PR DESCRIPTION
## Summary
- keep task updates alive when the page unloads

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686d2a957b18832aabf885747deda175