### PR TITLE
Add deadline property

### DIFF
--- a/src/main/java/com/example/demo/entity/Task.java
+++ b/src/main/java/com/example/demo/entity/Task.java
@@ -11,6 +11,7 @@ public class Task {
     private String title; // タスク名
     private String category; // 区分
     private LocalDate dueDate; // 期日
+    private LocalDateTime deadline; // 締切日時
     private String timeUntilDue; // 期日までを表す文字列
     private String result; // 結果
     private String detail; // 詳細

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -33,6 +33,7 @@ public class TaskServiceImpl implements TaskService {
         for (Task t : list) {
             if (t.getCompletedAt() != null) {
                 t.setTimeUntilDue(null);
+                t.setDeadline(null);
                 continue;
             }
             LocalDateTime deadline;
@@ -68,6 +69,7 @@ public class TaskServiceImpl implements TaskService {
                     deadline = today.plusDays(1).atStartOfDay();
                 }
             }
+            t.setDeadline(deadline);
             long minutes = Duration.between(now, deadline).toMinutes();
             if (minutes < 0)
                 minutes = 0;

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -100,8 +100,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const days = Math.floor(diff / (60 * 24));
     const hours = Math.floor((diff % (60 * 24)) / 60);
     const mins = diff % 60;
-    const cell = row.cells[5];
-    if (cell) cell.textContent = `${days}日${hours}時間${mins}分`;
+    const deadlineCell = row.cells[5];
+    if (deadlineCell) {
+      deadlineCell.textContent = deadline.toISOString().slice(0, 16).replace('T', ' ');
+    }
+    const diffCell = row.cells[6];
+    if (diffCell) diffCell.textContent = `${days}日${hours}時間${mins}分`;
   }
 
   function sortTaskTable(table) {
@@ -151,8 +155,8 @@ document.addEventListener('DOMContentLoaded', () => {
         comp.value = new Date().toISOString().split('T')[0];
         btn.value = '取消';
         moveRow(row, true);
-        const cell = row.cells[5];
-        if (cell) cell.textContent = '';
+        const diffCell = row.cells[6];
+        if (diffCell) diffCell.textContent = '';
         sortAllTaskTables();
       } else {
         comp.value = '';

--- a/src/main/resources/templates/task-box.html
+++ b/src/main/resources/templates/task-box.html
@@ -19,6 +19,7 @@
         <th>ページ</th>
         <th>タスク・疑問調査</th>
         <th>区分</th>
+        <th>締切</th>
         <th>期日</th>
         <th>結果</th>
         <th>詳細</th>
@@ -39,6 +40,7 @@
             <option value="再来週" th:selected="${task.category == '再来週'}">再来週</option>
           </select>
         </td>
+        <td th:text="${#temporals.format(task.deadline, 'yyyy-MM-dd HH:mm')}"></td>
         <td th:text="${task.timeUntilDue}"></td>
         <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
         <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>
@@ -62,6 +64,7 @@
         <th>ページ</th>
         <th>タスク・疑問調査</th>
         <th>区分</th>
+        <th>締切</th>
         <th>期日</th>
         <th>結果</th>
         <th>詳細</th>
@@ -82,6 +85,7 @@
             <option value="再来週" th:selected="${task.category == '再来週'}">再来週</option>
           </select>
         </td>
+        <td th:text="${#temporals.format(task.deadline, 'yyyy-MM-dd HH:mm')}"></td>
         <td th:text="${task.timeUntilDue}"></td>
         <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
         <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -142,6 +142,7 @@
             <th>ページ</th>
             <th>タスク・疑問調査</th>
             <th>区分</th>
+            <th>締切</th>
             <th>期日</th>
             <!-- <th>結果</th>
             <th>詳細</th> -->
@@ -162,6 +163,7 @@
                 <option value="再来週" th:selected="${task.category == '再来週'}">再来週</option>
               </select>
             </td>
+            <td th:text="${#temporals.format(task.deadline, 'yyyy-MM-dd HH:mm')}"></td>
             <td th:text="${task.timeUntilDue}"></td>
             <!-- <td><input type="text" th:value="${task.result}" class="task-result-input" /></td>
               <td><input type="text" th:value="${task.detail}" class="task-detail-input" /></td> -->


### PR DESCRIPTION
## Summary
- track a `deadline` timestamp for tasks
- surface new deadline information in the UI
- update JS to calculate and display deadline when task category changes

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686d2ec19b9c832a995dc97c23ec3384