### PR TITLE
Store task deadline in DB

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -78,14 +78,13 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void updateTask(Task task) {
-        boolean completedFlag = task.getCompletedAt() != null;
-        String sql = "UPDATE tasks SET title = ?, category = ?, result = ?, detail = ?, level = ?, completed_at = ?, "
-                + (completedFlag ? "due_date = NULL, " : "")
-                + "updated_at = NOW() WHERE id = ?";
-        java.sql.Date completed = completedFlag ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
+        String sql = "UPDATE tasks SET title = ?, category = ?, due_date = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
+        java.sql.Date due = task.getDueDate() != null ? java.sql.Date.valueOf(task.getDueDate()) : null;
+        java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
         jdbcTemplate.update(sql,
                 task.getTitle(),
                 task.getCategory(),
+                due,
                 task.getResult(),
                 task.getDetail(),
                 task.getLevel(),


### PR DESCRIPTION
## Summary
- calculate deadline for each task based on category
- store calculated deadline date when adding or updating tasks
- persist due date via updated SQL statements

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent-3.5.3.pom)*

------
https://chatgpt.com/codex/tasks/task_e_686d316d7fbc832ab1cb84061a8b4847