### PR TITLE
Fix deadline persistence

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -22,7 +22,7 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public List<Task> findAll() {
-        String sql = "SELECT id, title, category, due_date, result, detail, level, created_at, updated_at, completed_at "
+        String sql = "SELECT id, title, category, due_date, deadline, result, detail, level, created_at, updated_at, completed_at "
                 + "FROM tasks ORDER BY CASE category "
                 + "WHEN '今日' THEN 1 "
                 + "WHEN '明日' THEN 2 "
@@ -40,6 +40,10 @@ public class TaskRepositoryImpl implements TaskRepository {
                 java.sql.Date due = rs.getDate("due_date");
                 if (due != null) {
                     t.setDueDate(due.toLocalDate());
+                }
+                java.sql.Timestamp deadline = rs.getTimestamp("deadline");
+                if (deadline != null) {
+                    t.setDeadline(deadline.toLocalDateTime());
                 }
                 t.setResult(rs.getString("result"));
                 t.setDetail(rs.getString("detail"));
@@ -63,13 +67,15 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void insertTask(Task task) {
-        String sql = "INSERT INTO tasks (title, category, due_date, result, detail, level, created_at, updated_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)";
+        String sql = "INSERT INTO tasks (title, category, due_date, deadline, result, detail, level, created_at, updated_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)";
         java.sql.Date due = task.getDueDate() != null ? java.sql.Date.valueOf(task.getDueDate()) : null;
+        java.sql.Timestamp deadline = task.getDeadline() != null ? java.sql.Timestamp.valueOf(task.getDeadline()) : null;
         java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
         jdbcTemplate.update(sql,
                 task.getTitle(),
                 task.getCategory(),
                 due,
+                deadline,
                 task.getResult(),
                 task.getDetail(),
                 task.getLevel(),
@@ -78,13 +84,15 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void updateTask(Task task) {
-        String sql = "UPDATE tasks SET title = ?, category = ?, due_date = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
+        String sql = "UPDATE tasks SET title = ?, category = ?, due_date = ?, deadline = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
         java.sql.Date due = task.getDueDate() != null ? java.sql.Date.valueOf(task.getDueDate()) : null;
+        java.sql.Timestamp deadline = task.getDeadline() != null ? java.sql.Timestamp.valueOf(task.getDeadline()) : null;
         java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
         jdbcTemplate.update(sql,
                 task.getTitle(),
                 task.getCategory(),
                 due,
+                deadline,
                 task.getResult(),
                 task.getDetail(),
                 task.getLevel(),


### PR DESCRIPTION
## Summary
- include `deadline` column in task queries
- store deadline when inserting or updating tasks

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d37dd5320832a84ca1a366ffff355