### PR TITLE
Remove unused due_date field

### DIFF
--- a/src/main/java/com/example/demo/entity/Task.java
+++ b/src/main/java/com/example/demo/entity/Task.java
@@ -10,7 +10,6 @@ public class Task {
     private int id; // 自動採番ID
     private String title; // タスク名
     private String category; // 区分
-    private LocalDate dueDate; // 期日
     private LocalDateTime deadline; // 締切日時
     private String timeUntilDue; // 期日までを表す文字列
     private String result; // 結果

--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.example.demo.repository.task;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -22,7 +21,7 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public List<Task> findAll() {
-        String sql = "SELECT id, title, category, due_date, deadline, result, detail, level, created_at, updated_at, completed_at "
+        String sql = "SELECT id, title, category, deadline, result, detail, level, created_at, updated_at, completed_at "
                 + "FROM tasks ORDER BY CASE category "
                 + "WHEN '今日' THEN 1 "
                 + "WHEN '明日' THEN 2 "
@@ -37,10 +36,6 @@ public class TaskRepositoryImpl implements TaskRepository {
                 t.setId(rs.getInt("id"));
                 t.setTitle(rs.getString("title"));
                 t.setCategory(rs.getString("category"));
-                java.sql.Date due = rs.getDate("due_date");
-                if (due != null) {
-                    t.setDueDate(due.toLocalDate());
-                }
                 java.sql.Timestamp deadline = rs.getTimestamp("deadline");
                 if (deadline != null) {
                     t.setDeadline(deadline.toLocalDateTime());
@@ -67,14 +62,12 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void insertTask(Task task) {
-        String sql = "INSERT INTO tasks (title, category, due_date, deadline, result, detail, level, created_at, updated_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)";
-        java.sql.Date due = task.getDueDate() != null ? java.sql.Date.valueOf(task.getDueDate()) : null;
+        String sql = "INSERT INTO tasks (title, category, deadline, result, detail, level, created_at, updated_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)";
         java.sql.Timestamp deadline = task.getDeadline() != null ? java.sql.Timestamp.valueOf(task.getDeadline()) : null;
         java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
         jdbcTemplate.update(sql,
                 task.getTitle(),
                 task.getCategory(),
-                due,
                 deadline,
                 task.getResult(),
                 task.getDetail(),
@@ -84,14 +77,12 @@ public class TaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void updateTask(Task task) {
-        String sql = "UPDATE tasks SET title = ?, category = ?, due_date = ?, deadline = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
-        java.sql.Date due = task.getDueDate() != null ? java.sql.Date.valueOf(task.getDueDate()) : null;
+        String sql = "UPDATE tasks SET title = ?, category = ?, deadline = ?, result = ?, detail = ?, level = ?, completed_at = ?, updated_at = NOW() WHERE id = ?";
         java.sql.Timestamp deadline = task.getDeadline() != null ? java.sql.Timestamp.valueOf(task.getDeadline()) : null;
         java.sql.Date completed = task.getCompletedAt() != null ? java.sql.Date.valueOf(task.getCompletedAt()) : null;
         jdbcTemplate.update(sql,
                 task.getTitle(),
                 task.getCategory(),
-                due,
                 deadline,
                 task.getResult(),
                 task.getDetail(),

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -112,7 +112,6 @@ public class TaskServiceImpl implements TaskService {
         log.debug("Adding task {}", task.getTitle());
         LocalDateTime deadline = calculateDeadline(task.getCategory());
         task.setDeadline(deadline);
-        task.setDueDate(deadline.toLocalDate());
         repository.insertTask(task);
     }
 
@@ -122,9 +121,6 @@ public class TaskServiceImpl implements TaskService {
         if (task.getCompletedAt() == null) {
             LocalDateTime deadline = calculateDeadline(task.getCategory());
             task.setDeadline(deadline);
-            task.setDueDate(deadline.toLocalDate());
-        } else {
-            task.setDueDate(null);
         }
         repository.updateTask(task);
     }


### PR DESCRIPTION
## Summary
- drop `dueDate` field from `Task`
- update repository queries to remove `due_date` column
- simplify `TaskServiceImpl` accordingly

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_686d3a8ee4d8832aa8b279bbc74332f4