### PR TITLE
Fix toggling of newly completed schedules

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -364,10 +364,17 @@ document.addEventListener('DOMContentLoaded', () => {
     if (completed) {
       if (completedShown) {
         addSchedule(title, date, { completed: true, id });
-        console.log('AAA');
+        // keep track so the item can be removed when toggling display
+        if (!displayedCompleted.some((d) => d.id === id && d.date === date)) {
+          displayedCompleted.push({ id, date });
+        }
       }
     } else {
       addSchedule(title, date, { id });
+      // remove from tracking list in case it was previously completed
+      displayedCompleted = displayedCompleted.filter(
+        (d) => !(d.id === id && d.date === date)
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- keep track of newly completed events so they get removed when hiding

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e30f94c70832a9e39b3901ceddbf7