### PR TITLE
Add expired indicator for tasks

### DIFF
--- a/src/main/java/com/example/demo/entity/Task.java
+++ b/src/main/java/com/example/demo/entity/Task.java
@@ -18,4 +18,5 @@ public class Task {
     private LocalDateTime createdAt; // 作成日時
     private LocalDateTime updatedAt; // 更新日時
     private LocalDate completedAt; // 完了日
+    private boolean expired; // 期限切れかどうか
 }

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -99,6 +99,7 @@ public class TaskServiceImpl implements TaskService {
             }
 
             long minutes = Duration.between(now, deadline).toMinutes();
+            boolean expired = minutes <= 0;
             if (minutes < 0)
                 minutes = 0;
             long rounded = (minutes / 5) * 5;
@@ -106,6 +107,7 @@ public class TaskServiceImpl implements TaskService {
             long hours = (rounded % (60 * 24)) / 60;
             long mins = rounded % 60;
             t.setTimeUntilDue(String.format("%d日%d時間%d分", days, hours, mins));
+            t.setExpired(expired);
 
             String newCategory;
             if (minutes <= 60 * 24) {

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -95,6 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     deadline.setHours(0, 0, 0, 0);
     let diff = Math.floor((deadline - now) / 60000);
+    const expired = diff <= 0;
     if (diff < 0) diff = 0;
     diff = Math.floor(diff / 5) * 5;
     const days = Math.floor(diff / (60 * 24));
@@ -110,7 +111,15 @@ document.addEventListener('DOMContentLoaded', () => {
       deadlineCell.textContent = `${y}-${m}-${d} ${hh}:${mm}`;
     }
     const diffCell = row.cells[6];
-    if (diffCell) diffCell.textContent = `${days}日${hours}時間${mins}分`;
+    if (diffCell) {
+      if (expired) {
+        diffCell.textContent = '期限切れ';
+        diffCell.style.color = 'red';
+      } else {
+        diffCell.textContent = `${days}日${hours}時間${mins}分`;
+        diffCell.style.color = '';
+      }
+    }
   }
 
   function sortTaskTable(table) {

--- a/src/main/resources/templates/task-box.html
+++ b/src/main/resources/templates/task-box.html
@@ -41,7 +41,7 @@
           </td>
           <!-- （例：2024-06-07 14:30）の形で表示 -->
           <td th:text="${#temporals.format(task.deadline, 'yyyy-MM-dd HH:mm')}"></td>
-          <td th:text="${task.timeUntilDue}"></td>
+          <td th:text="${task.expired ? '期限切れ' : task.timeUntilDue}" th:style="${task.expired} ? 'color:red' : ''"></td>
           <td>
             <select class="task-level-select">
               <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == task.level}"></option>
@@ -82,7 +82,7 @@
             </select>
           </td>
           <td th:text="${#temporals.format(task.deadline, 'yyyy-MM-dd HH:mm')}"></td>
-          <td th:text="${task.timeUntilDue}"></td>
+          <td th:text="${task.expired ? '期限切れ' : task.timeUntilDue}" th:style="${task.expired} ? 'color:red' : ''"></td>
           <td>
             <select class="task-level-select">
               <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == task.level}"></option>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -170,7 +170,7 @@
               </select>
             </td>
             <td th:text="${#temporals.format(task.deadline, 'yyyy-MM-dd HH:mm')}"></td>
-            <td th:text="${task.timeUntilDue}"></td>
+            <td th:text="${task.expired ? '期限切れ' : task.timeUntilDue}" th:style="${task.expired} ? 'color:red' : ''"></td>
             <td>
               <select class="task-level-select">
                 <option th:each="level : ${#numbers.sequence(1,5)}" th:value="${level}" th:text="${level}" th:selected="${level == task.level}"></option>


### PR DESCRIPTION
## Summary
- track expiry state on tasks
- mark tasks as expired if deadline has passed
- display `期限切れ` in red when expired
- update task.js to handle expiry dynamically

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e63a43b38832ab15073073f2da775