### PR TITLE
Fix table spacing and align headers

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -46,6 +46,17 @@ body.task-body {
   margin: 0;
 }
 
+/* spacing between task table and awareness/word tables */
+.database-container + .database-row {
+  margin-top: 40px;
+}
+
+/* unify header height for awareness and word tables */
+.awareness-database th,
+.word-database th {
+  height: 32px;
+}
+
 #new-schedule-button {
   /* 新規ボタン */
   /* margin-top: 10px; 相対位置*/


### PR DESCRIPTION
## Summary
- add space between task and awareness/word tables
- ensure header heights are consistent for awareness and word tables

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686e6bb06b14832a880083bcee963226