### PR TITLE
Add word record support

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -14,6 +14,7 @@ import com.example.demo.service.challenge.ChallengeService;
 import com.example.demo.service.schedule.ScheduleService;
 import com.example.demo.service.task.TaskService;
 import com.example.demo.service.awareness.AwarenessRecordService;
+import com.example.demo.service.word.WordRecordService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,7 @@ public class TopController {
     private final ChallengeService challengeService;
     private final TaskService taskService;
     private final AwarenessRecordService awarenessRecordService;
+    private final WordRecordService wordRecordService;
 
     @GetMapping("/{username}/task-top")
     public String showTaskTop(@PathVariable String username, Model model, HttpSession session) {
@@ -53,6 +55,11 @@ public class TopController {
                 .limit(5)
                 .toList();
         model.addAttribute("awarenessRecords", awarenessList);
+        var wordList = wordRecordService.getAllRecords()
+                .stream()
+                .limit(5)
+                .toList();
+        model.addAttribute("wordRecords", wordList);
         model.addAttribute("username", username);
         return "task-top";
     }

--- a/src/main/java/com/example/demo/controller/WordRecordController.java
+++ b/src/main/java/com/example/demo/controller/WordRecordController.java
@@ -1,0 +1,41 @@
+package com.example.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.WordRecord;
+import com.example.demo.service.word.WordRecordService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class WordRecordController {
+
+    private final WordRecordService service;
+
+    @PostMapping("/word-add")
+    public ResponseEntity<Void> addRecord(@RequestBody WordRecord record) {
+        log.debug("Adding word record");
+        service.addRecord(record);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/word-update")
+    public ResponseEntity<Void> updateRecord(@RequestBody WordRecord record) {
+        log.debug("Updating word record id {}", record.getId());
+        service.updateRecord(record);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/word-delete")
+    public ResponseEntity<Void> deleteRecord(@RequestBody WordRecord record) {
+        log.debug("Deleting word record id {}", record.getId());
+        service.deleteById(record.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/entity/WordRecord.java
+++ b/src/main/java/com/example/demo/entity/WordRecord.java
@@ -1,0 +1,11 @@
+package com.example.demo.entity;
+
+import lombok.Data;
+
+@Data
+public class WordRecord {
+    private int id;      // ID
+    private String word; // 単語
+    private String meaning; // 意味
+    private String example; // 例文
+}

--- a/src/main/java/com/example/demo/repository/word/WordRecordRepository.java
+++ b/src/main/java/com/example/demo/repository/word/WordRecordRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.repository.word;
+
+import java.util.List;
+
+import com.example.demo.entity.WordRecord;
+
+public interface WordRecordRepository {
+    List<WordRecord> findAll();
+    void insertRecord(WordRecord record);
+    void updateRecord(WordRecord record);
+    void deleteById(int id);
+}

--- a/src/main/java/com/example/demo/repository/word/WordRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/word/WordRecordRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.example.demo.repository.word;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.WordRecord;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class WordRecordRepositoryImpl implements WordRecordRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<WordRecord> findAll() {
+        String sql = "SELECT id, word, meaning, example FROM word_records ORDER BY id DESC";
+        return jdbcTemplate.query(sql, new RowMapper<WordRecord>() {
+            @Override
+            public WordRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
+                WordRecord w = new WordRecord();
+                w.setId(rs.getInt("id"));
+                w.setWord(rs.getString("word"));
+                w.setMeaning(rs.getString("meaning"));
+                w.setExample(rs.getString("example"));
+                return w;
+            }
+        });
+    }
+
+    @Override
+    public void insertRecord(WordRecord record) {
+        String sql = "INSERT INTO word_records (word, meaning, example) VALUES (?, ?, ?)";
+        jdbcTemplate.update(sql,
+                record.getWord(),
+                record.getMeaning(),
+                record.getExample());
+    }
+
+    @Override
+    public void updateRecord(WordRecord record) {
+        String sql = "UPDATE word_records SET word = ?, meaning = ?, example = ? WHERE id = ?";
+        jdbcTemplate.update(sql,
+                record.getWord(),
+                record.getMeaning(),
+                record.getExample(),
+                record.getId());
+    }
+
+    @Override
+    public void deleteById(int id) {
+        String sql = "DELETE FROM word_records WHERE id = ?";
+        jdbcTemplate.update(sql, id);
+    }
+}

--- a/src/main/java/com/example/demo/service/word/WordRecordService.java
+++ b/src/main/java/com/example/demo/service/word/WordRecordService.java
@@ -1,0 +1,12 @@
+package com.example.demo.service.word;
+
+import java.util.List;
+
+import com.example.demo.entity.WordRecord;
+
+public interface WordRecordService {
+    List<WordRecord> getAllRecords();
+    void addRecord(WordRecord record);
+    void updateRecord(WordRecord record);
+    void deleteById(int id);
+}

--- a/src/main/java/com/example/demo/service/word/WordRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/word/WordRecordServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.demo.service.word;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.WordRecord;
+import com.example.demo.repository.word.WordRecordRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WordRecordServiceImpl implements WordRecordService {
+
+    private final WordRecordRepository repository;
+
+    @Override
+    public List<WordRecord> getAllRecords() {
+        log.debug("Fetching all word records");
+        return repository.findAll();
+    }
+
+    @Override
+    public void addRecord(WordRecord record) {
+        log.debug("Adding word record {}", record.getWord());
+        repository.insertRecord(record);
+    }
+
+    @Override
+    public void updateRecord(WordRecord record) {
+        log.debug("Updating word record id {}", record.getId());
+        repository.updateRecord(record);
+    }
+
+    @Override
+    public void deleteById(int id) {
+        log.debug("Deleting word record id {}", id);
+        repository.deleteById(id);
+    }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -96,6 +96,12 @@ body.task-body {
   left: 50px;
 }
 
+#new-word-button {
+  position: fixed;
+  top: 440px;
+  left: 50px;
+}
+
 /* task-top.html だけの処理*/
 
 .calendar-area {

--- a/src/main/resources/static/js/word.js
+++ b/src/main/resources/static/js/word.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('#new-word-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      fetch('/word-add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ word: '', meaning: '', example: '' })
+      }).then(() => location.reload());
+    });
+  });
+
+  function gatherData(row) {
+    return {
+      id: parseInt(row.dataset.id, 10),
+      word: row.querySelector('.word-input').value,
+      meaning: row.querySelector('.meaning-input').value,
+      example: row.querySelector('.example-input').value
+    };
+  }
+
+  function sendUpdate(row) {
+    const data = gatherData(row);
+    return fetch('/word-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+
+  document.querySelectorAll('.word-input, .meaning-input, .example-input').forEach((el) => {
+    el.addEventListener('input', () => {
+      const row = el.closest('tr');
+      if (row) sendUpdate(row);
+    });
+  });
+
+  document.querySelectorAll('.word-delete-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/word-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) })
+      }).then(() => location.reload());
+    });
+  });
+});

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -102,6 +102,7 @@
         <button id="new-challenge-button">挑戦新規</button>
         <button id="new-task-button">タスク新規</button>
         <button id="new-awareness-button">新規気づき</button>
+        <button id="new-word-button">新規単語</button>
       </div>
 
       <div class="database-container">
@@ -209,14 +210,16 @@
         <div class="database-container">
           <table class="word-database">
             <tr>
+              <th>削除</th>
               <th>単語</th>
               <th>意味</th>
               <th>例</th>
             </tr>
-            <tr>
-              <td><input type="text" class="word-input" /></td>
-              <td><input type="text" class="meaning-input" /></td>
-              <td><input type="text" class="example-input" /></td>
+            <tr th:each="word : ${wordRecords}" th:data-id="${word.id}">
+              <td><input type="button" value="削除" class="word-delete-button" /></td>
+              <td><input type="text" th:value="${word.word}" class="word-input" /></td>
+              <td><input type="text" th:value="${word.meaning}" class="meaning-input" /></td>
+              <td><input type="text" th:value="${word.example}" class="example-input" /></td>
             </tr>
           </table>
         </div>
@@ -235,6 +238,7 @@
       <script th:src="@{/js/schedule.js}"></script>
       <script th:src="@{/js/task.js}"></script>
       <script th:src="@{/js/awareness.js}"></script>
+      <script th:src="@{/js/word.js}"></script>
       <script th:src="@{/js/calendar-detail.js}"></script>
     </body>
   </html>


### PR DESCRIPTION
## Summary
- add entity, repo, service, and controller for WordRecord
- fetch word records in TopController and expose on task top page
- display words in the page and add "新規単語" button
- include JS and CSS for word operations

## Testing
- `mvn -q test` *(fails: Could not transfer parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d184270832ab9e57b13366c3e9a