### PR TITLE
Fix awareness table vertical alignment

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -40,7 +40,7 @@ body.task-body {
   margin-top: -60px;
   display: flex;
   gap: 40px;
-  align-items: flex-start;
+  align-items: flex-end;
 }
 
 .database-row .database-container {


### PR DESCRIPTION
## Summary
- align the awareness table by adjusting `.database-row` to use `flex-end`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686e7cbbbe08832a934d0bc0fb219dac