### PR TITLE
Include word record count in total point

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -145,6 +145,7 @@ public class TopController {
         int challengePoints = challengeService.getTotalCompletedPoints();
         int taskPoints = taskService.getTotalCompletedLevels();
         int awareness = awarenessRecordService.getTotalAwarenessLevel();
-        return schedulePoints + challengePoints + taskPoints + awareness * 0.5;
+        int wordCount = wordRecordService.countRecords();
+        return schedulePoints + challengePoints + taskPoints + awareness * 0.5 + wordCount * 0.5;
     }
 }

--- a/src/main/java/com/example/demo/repository/word/WordRecordRepository.java
+++ b/src/main/java/com/example/demo/repository/word/WordRecordRepository.java
@@ -9,4 +9,5 @@ public interface WordRecordRepository {
     void insertRecord(WordRecord record);
     void updateRecord(WordRecord record);
     void deleteById(int id);
+    int countRecords();
 }

--- a/src/main/java/com/example/demo/repository/word/WordRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/word/WordRecordRepositoryImpl.java
@@ -58,4 +58,11 @@ public class WordRecordRepositoryImpl implements WordRecordRepository {
         String sql = "DELETE FROM word_records WHERE id = ?";
         jdbcTemplate.update(sql, id);
     }
+
+    @Override
+    public int countRecords() {
+        String sql = "SELECT COUNT(*) FROM word_records";
+        Integer result = jdbcTemplate.queryForObject(sql, Integer.class);
+        return result != null ? result : 0;
+    }
 }

--- a/src/main/java/com/example/demo/service/word/WordRecordService.java
+++ b/src/main/java/com/example/demo/service/word/WordRecordService.java
@@ -9,4 +9,5 @@ public interface WordRecordService {
     void addRecord(WordRecord record);
     void updateRecord(WordRecord record);
     void deleteById(int id);
+    int countRecords();
 }

--- a/src/main/java/com/example/demo/service/word/WordRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/word/WordRecordServiceImpl.java
@@ -40,4 +40,10 @@ public class WordRecordServiceImpl implements WordRecordService {
         log.debug("Deleting word record id {}", id);
         repository.deleteById(id);
     }
+
+    @Override
+    public int countRecords() {
+        log.debug("Counting word records");
+        return repository.countRecords();
+    }
 }


### PR DESCRIPTION
## Summary
- count word records in repository/service
- expose new method from WordRecordService
- update TopController `getTotalPoint()` to add word count * 0.5

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686e81baeb30832ab60c468c5951d56e