### PR TITLE
Enable word box page

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -136,6 +136,19 @@ public class TopController {
         model.addAttribute("username", username);
         return "awareness-box";
     }
+
+    @GetMapping("/{username}/task-top/word-box")
+    public String showWordBox(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying word box page");
+        var records = wordRecordService.getAllRecords();
+        model.addAttribute("wordRecords", records);
+        model.addAttribute("username", username);
+        return "word-box";
+    }
     //-------------------------------------------------------------------------------------------------
     @GetMapping("/total-point")
     @ResponseBody

--- a/src/main/resources/templates/word-box.html
+++ b/src/main/resources/templates/word-box.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>単語ボックス</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+    </div>
+
+    <div class="database-container">
+      <table class="word-database">
+        <tr>
+          <th>削除</th>
+          <th>単語</th>
+          <th>意味</th>
+          <th>例</th>
+        </tr>
+        <tr th:each="word : ${wordRecords}" th:data-id="${word.id}">
+          <td><input type="button" value="削除" class="word-delete-button" /></td>
+          <td><input type="text" th:value="${word.word}" class="word-input" /></td>
+          <td><input type="text" th:value="${word.meaning}" class="meaning-input" /></td>
+          <td><input type="text" th:value="${word.example}" class="example-input" /></td>
+        </tr>
+      </table>
+      <button id="new-word-button">新規単語</button>
+    </div>
+
+    <script th:src="@{/js/word.js}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a page to view all words (`word-box.html`)
- enable access to the page via `/task-top/word-box` mapping

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e853e60a4832aba23068bedd8dd9b