### PR TITLE
Update deadline update logic

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepository.java
@@ -6,6 +6,7 @@ import com.example.demo.entity.Task;
 
 public interface TaskRepository {
     List<Task> findAll();
+    Task findById(int id);
     void insertTask(Task task);
     void updateTask(Task task);
     void deleteById(int id);

--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -61,6 +61,41 @@ public class TaskRepositoryImpl implements TaskRepository {
     }
 
     @Override
+    public Task findById(int id) {
+        String sql = "SELECT id, title, category, deadline, result, detail, level, created_at, updated_at, completed_at "
+                + "FROM tasks WHERE id = ?";
+        return jdbcTemplate.queryForObject(sql, new RowMapper<Task>() {
+            @Override
+            public Task mapRow(ResultSet rs, int rowNum) throws SQLException {
+                Task t = new Task();
+                t.setId(rs.getInt("id"));
+                t.setTitle(rs.getString("title"));
+                t.setCategory(rs.getString("category"));
+                java.sql.Timestamp deadline = rs.getTimestamp("deadline");
+                if (deadline != null) {
+                    t.setDeadline(deadline.toLocalDateTime());
+                }
+                t.setResult(rs.getString("result"));
+                t.setDetail(rs.getString("detail"));
+                t.setLevel(rs.getInt("level"));
+                java.sql.Timestamp created = rs.getTimestamp("created_at");
+                if (created != null) {
+                    t.setCreatedAt(created.toLocalDateTime());
+                }
+                java.sql.Timestamp updated = rs.getTimestamp("updated_at");
+                if (updated != null) {
+                    t.setUpdatedAt(updated.toLocalDateTime());
+                }
+                java.sql.Date completed = rs.getDate("completed_at");
+                if (completed != null) {
+                    t.setCompletedAt(completed.toLocalDate());
+                }
+                return t;
+            }
+        }, id);
+    }
+
+    @Override
     public void insertTask(Task task) {
         String sql = "INSERT INTO tasks (title, category, deadline, result, detail, level, created_at, updated_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW(), ?)";
         java.sql.Timestamp deadline = task.getDeadline() != null ? java.sql.Timestamp.valueOf(task.getDeadline()) : null;


### PR DESCRIPTION
## Summary
- add `findById` to `TaskRepository`
- update repository implementation to support single record retrieval
- adjust `TaskServiceImpl` so deadlines only update when category changes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686e893e2b30832a969732f270707673