### PR TITLE
Fix schedule expiration display

### DIFF
--- a/src/main/java/com/example/demo/entity/Schedule.java
+++ b/src/main/java/com/example/demo/entity/Schedule.java
@@ -20,4 +20,5 @@ public class Schedule {
     private int point;               // ポイント
     private LocalDate completedDay;  // 完了日（null 可）
     private String timeUntilStart;   // 開始時刻までを表す文字列
+    private boolean expired;         // 期限切れかどうか
 }

--- a/src/main/java/com/example/demo/repository/schedule/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/schedule/ScheduleRepositoryImpl.java
@@ -45,6 +45,7 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
                 if (comp != null) {
                     s.setCompletedDay(comp.toLocalDate());
                 }
+                s.setExpired(false);
                 return s;
             }
         });

--- a/src/main/java/com/example/demo/service/schedule/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/demo/service/schedule/ScheduleServiceImpl.java
@@ -29,18 +29,21 @@ public class ScheduleServiceImpl implements ScheduleService {
             //完了日がnullでない場合、つまり完了済みの予定の場合は、開始までの時間は表示しなくてよい。
             if (s.getCompletedDay() != null) {
                 s.setTimeUntilStart(null);//開始までの時間がnull
+                s.setExpired(false);
                 continue;
             }
 
             //未完了の予定の場合は、以下で完了までの時間を計算
             LocalDateTime start = LocalDateTime.of(s.getScheduleDate(), s.getStartTime());//合成して「2024-04-20T15:30:00」という日時を表す
             long minutes = Duration.between(now, start).toMinutes();//分単位で今から開始までの時間を取得
+            boolean expired = minutes <= 0;
             if (minutes < 0) minutes = 0;//期限切れ
             long rounded = (minutes / 5) * 5;//5分単位に変換
             long days = rounded / (60 * 24);//日
             long hours = (rounded % (60 * 24)) / 60;//時間
             long mins = rounded % 60;//分
             s.setTimeUntilStart(String.format("%d日%d時間%d分", days, hours, mins));
+            s.setExpired(expired);
         }
         
         return list;

--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -82,13 +82,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const start = new Date(`${dateStr}T${hourSel.value.padStart(2, '0')}:${minuteSel.value.padStart(2, '0')}:00`);
     const now = new Date();
     let diff = Math.floor((start - now) / 60000); // minutes
+    const expired = diff <= 0;
     if (diff < 0) diff = 0;
     diff = Math.floor(diff / 5) * 5;
     const days = Math.floor(diff / (60 * 24));
     const hours = Math.floor((diff % (60 * 24)) / 60);
     const mins = diff % 60;
     const span = row.querySelector('td:last-child span');
-    if (span) span.textContent = `${days}日${hours}時間${mins}分`;
+    if (span) {
+      if (expired) {
+        span.textContent = '期限切れ';
+        span.style.color = 'red';
+      } else {
+        span.textContent = `${days}日${hours}時間${mins}分`;
+        span.style.color = '';
+      }
+    }
   }
 
   const calendar = document.getElementById('calendar');

--- a/src/main/resources/templates/schedule-box.html
+++ b/src/main/resources/templates/schedule-box.html
@@ -56,7 +56,8 @@
           <td><input type="text" th:value="${schedule.feedback}" size="8" class="schedule-feedback-input" /></td>
           <td><input type="number" th:value="${schedule.point}" size="2" class="point-input" /></td>
           <td><input type="date" th:value="${schedule.completedDay}" class="completed-day-input" /></td>
-          <td><span th:text="${schedule.timeUntilStart}"></span></td>
+          <td><span th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}"
+                    th:style="${schedule.expired} ? 'color:red' : ''"></span></td>
           <td><input type="hidden" class="schedule-id" th:value="${schedule.id}" /></td>
         </tr>
       </table>
@@ -127,7 +128,8 @@
             <input type="date" th:value="${schedule.completedDay}" class="completed-day-input" />
           </td>
           <td>
-            <span th:text="${schedule.timeUntilStart}"></span>
+            <span th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}"
+                  th:style="${schedule.expired} ? 'color:red' : ''"></span>
           </td>
           <td><input type="hidden" class="schedule-id" th:value="${schedule.id}" /></td>
         </tr>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -87,7 +87,8 @@
               <input type="date" th:value="${schedule.completedDay}" class="completed-day-input" />
             </td>
             <td>
-              <span th:text="${schedule.timeUntilStart}"></span>
+              <span th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}"
+                    th:style="${schedule.expired} ? 'color:red' : ''"></span>
             </td>
             <td><input type="hidden" class="schedule-id" th:value="${schedule.id}" /></td>
           </tr>


### PR DESCRIPTION
## Summary
- add `expired` field to `Schedule`
- compute expiration in `ScheduleServiceImpl`
- update schedule repository to initialize `expired`
- show expired schedules with red text in templates
- handle expiry display client-side in `schedule.js`

## Testing
- `mvn -q -e -DskipTests=false test` *(fails: Non-resolvable parent POM)*
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5793c64832a8d578aa3d5086cb8