### PR TITLE
Fix schedule countdown lookup

### DIFF
--- a/src/main/resources/static/js/schedule.js
+++ b/src/main/resources/static/js/schedule.js
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.value = '取消';
         updateCalendarCompletion(row, true); //今表示中のやつ一回非表示にして、赤文字でカレンダーに表示
         moveRowBasedOnCompletion(row, true); //表面上の予定テーブルの更新
-        const span = row.querySelector('td:last-child span');
+        const span = row.querySelector('.time-until-start');
         //開始までの時間に何か入っているなら、nullに
         if (span) span.textContent = '';
         //取消ボタンが押されたら
@@ -231,7 +231,7 @@ document.addEventListener('DOMContentLoaded', () => {
       moveRowBasedOnCompletion(row, completed); //予定テーブルの移動や表示（表面上の）
       //完了日があるなら
       if (completed) {
-        const span = row.querySelector('td:last-child span');
+        const span = row.querySelector('.time-until-start');
         if (span) span.textContent = ''; //開始までをnullに
       } else {
         updateTimeUntilStart(row); //開始までの時間を表示
@@ -361,7 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const days = Math.floor(diff / (60 * 24));
     const hours = Math.floor((diff % (60 * 24)) / 60);
     const mins = diff % 60;
-    const span = row.querySelector('td:last-child span');
+    const span = row.querySelector('.time-until-start');
     console.log(days);
     if (span) {
       if (expired) {

--- a/src/main/resources/templates/schedule-box.html
+++ b/src/main/resources/templates/schedule-box.html
@@ -56,7 +56,7 @@
           <td><input type="text" th:value="${schedule.feedback}" size="8" class="schedule-feedback-input" /></td>
           <td><input type="number" th:value="${schedule.point}" size="2" class="point-input" /></td>
           <td><input type="date" th:value="${schedule.completedDay}" class="completed-day-input" /></td>
-          <td><span th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}"
+          <td><span class="time-until-start" th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}"
                     th:style="${schedule.expired} ? 'color:red' : ''"></span></td>
           <td><input type="hidden" class="schedule-id" th:value="${schedule.id}" /></td>
         </tr>
@@ -128,7 +128,7 @@
             <input type="date" th:value="${schedule.completedDay}" class="completed-day-input" />
           </td>
           <td>
-            <span th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}"
+            <span class="time-until-start" th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}"
                   th:style="${schedule.expired} ? 'color:red' : ''"></span>
           </td>
           <td><input type="hidden" class="schedule-id" th:value="${schedule.id}" /></td>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -86,7 +86,7 @@
             <input type="date" th:value="${schedule.completedDay}" class="completed-day-input" />
           </td>
           <td>
-            <span th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}" th:style="${schedule.expired} ? 'color:red' : ''"></span>
+            <span class="time-until-start" th:text="${schedule.expired ? '期限切れ' : schedule.timeUntilStart}" th:style="${schedule.expired} ? 'color:red' : ''"></span>
           </td>
           <td><input type="hidden" class="schedule-id" th:value="${schedule.id}" /></td>
         </tr>


### PR DESCRIPTION
## Summary
- add `.time-until-start` class on schedule countdown cells
- update `schedule.js` to use the new class instead of `td:last-child span`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6871568deecc832a8249fed6a47c14a2