### PR TITLE
Update cancel behavior for challenges

### DIFF
--- a/src/main/resources/static/js/challenge.js
+++ b/src/main/resources/static/js/challenge.js
@@ -105,7 +105,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const row = btn.closest('tr');
       if (!row) return;
       const actual = row.querySelector('.challenge-actual-input');
-      if (actual) actual.value = '';
+      if (actual) {
+        actual.value = actual.value
+          .replace(/^（成功）/, '')
+          .replace(/^（失敗）/, '')
+          .replace(/^\(成功\)/, '')
+          .replace(/^\(失敗\)/, '');
+      }
       const date = row.querySelector('.challenge-date-input');
       if (date) date.value = '';//挑戦日をnullに
       sendUpdate(row).then(refreshTotalPoint);//サーバサイドのデータベースを更新後，ポイント更新


### PR DESCRIPTION
## Summary
- make cancel button remove only the success/failure marks while keeping existing text

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_687162b368e8832ab7717c650e75df2e