### PR TITLE
Display subtasks on task page

### DIFF
--- a/src/main/java/com/example/demo/controller/SubTaskController.java
+++ b/src/main/java/com/example/demo/controller/SubTaskController.java
@@ -1,0 +1,41 @@
+package com.example.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.SubTask;
+import com.example.demo.service.subtask.SubTaskService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class SubTaskController {
+
+    private final SubTaskService service;
+
+    @PostMapping("/subtask-add")
+    public ResponseEntity<Void> addSubTask(@RequestBody SubTask subTask) {
+        log.debug("Adding subtask {}", subTask.getTitle());
+        service.addSubTask(subTask);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/subtask-update")
+    public ResponseEntity<Void> updateSubTask(@RequestBody SubTask subTask) {
+        log.debug("Updating subtask id {}", subTask.getId());
+        service.updateSubTask(subTask);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/subtask-delete")
+    public ResponseEntity<Void> deleteSubTask(@RequestBody SubTask subTask) {
+        log.debug("Deleting subtask id {}", subTask.getId());
+        service.deleteSubTaskById(subTask.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/controller/TaskPageController.java
+++ b/src/main/java/com/example/demo/controller/TaskPageController.java
@@ -14,6 +14,7 @@ import com.example.demo.entity.Task;
 import com.example.demo.entity.TaskPage;
 import com.example.demo.service.page.TaskPageService;
 import com.example.demo.service.task.TaskService;
+import com.example.demo.service.subtask.SubTaskService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ public class TaskPageController {
 
     private final TaskPageService service;
     private final TaskService taskService;
+    private final SubTaskService subTaskService;
 
     @GetMapping("/{username}/task-top/task-page/{taskId}")
     public String showTaskPage(@PathVariable String username, @PathVariable int taskId,
@@ -39,6 +41,7 @@ public class TaskPageController {
                 .filter(t -> t.getId() == taskId)
                 .findFirst()
                 .orElse(null);
+        model.addAttribute("subTasks", subTaskService.getSubTasks(taskId));
         model.addAttribute("page", page);
         model.addAttribute("task", task);
         model.addAttribute("username", username);

--- a/src/main/java/com/example/demo/entity/SubTask.java
+++ b/src/main/java/com/example/demo/entity/SubTask.java
@@ -1,0 +1,17 @@
+package com.example.demo.entity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class SubTask {
+    private int id; // 自動採番ID
+    private int taskId; // 親タスクID
+    private String title; // 子タスク名
+    private LocalDateTime deadline; // 締切
+    private String timeUntilDue; // 期日
+    private LocalDate completedAt; // 完了日
+    private boolean expired; // 期限切れかどうか
+}

--- a/src/main/java/com/example/demo/repository/subtask/SubTaskRepository.java
+++ b/src/main/java/com/example/demo/repository/subtask/SubTaskRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.repository.subtask;
+
+import java.util.List;
+
+import com.example.demo.entity.SubTask;
+
+public interface SubTaskRepository {
+    List<SubTask> findByTaskId(int taskId);
+    void insertSubTask(SubTask subTask);
+    void updateSubTask(SubTask subTask);
+    void deleteById(int id);
+}

--- a/src/main/java/com/example/demo/repository/subtask/SubTaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/subtask/SubTaskRepositoryImpl.java
@@ -1,0 +1,67 @@
+package com.example.demo.repository.subtask;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.SubTask;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SubTaskRepositoryImpl implements SubTaskRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final RowMapper<SubTask> ROW_MAPPER = new RowMapper<SubTask>() {
+        @Override
+        public SubTask mapRow(ResultSet rs, int rowNum) throws SQLException {
+            SubTask s = new SubTask();
+            s.setId(rs.getInt("id"));
+            s.setTaskId(rs.getInt("task_id"));
+            s.setTitle(rs.getString("title"));
+            java.sql.Timestamp deadline = rs.getTimestamp("deadline");
+            if (deadline != null) {
+                s.setDeadline(deadline.toLocalDateTime());
+            }
+            java.sql.Date completed = rs.getDate("completed_at");
+            if (completed != null) {
+                s.setCompletedAt(completed.toLocalDate());
+            }
+            return s;
+        }
+    };
+
+    @Override
+    public List<SubTask> findByTaskId(int taskId) {
+        String sql = "SELECT id, task_id, title, deadline, completed_at FROM sub_tasks WHERE task_id = ? ORDER BY id";
+        return jdbcTemplate.query(sql, ROW_MAPPER, taskId);
+    }
+
+    @Override
+    public void insertSubTask(SubTask subTask) {
+        String sql = "INSERT INTO sub_tasks (task_id, title, deadline, completed_at) VALUES (?, ?, ?, ?)";
+        java.sql.Timestamp deadline = subTask.getDeadline() != null ? java.sql.Timestamp.valueOf(subTask.getDeadline()) : null;
+        java.sql.Date completed = subTask.getCompletedAt() != null ? java.sql.Date.valueOf(subTask.getCompletedAt()) : null;
+        jdbcTemplate.update(sql, subTask.getTaskId(), subTask.getTitle(), deadline, completed);
+    }
+
+    @Override
+    public void updateSubTask(SubTask subTask) {
+        String sql = "UPDATE sub_tasks SET title = ?, deadline = ?, completed_at = ? WHERE id = ?";
+        java.sql.Timestamp deadline = subTask.getDeadline() != null ? java.sql.Timestamp.valueOf(subTask.getDeadline()) : null;
+        java.sql.Date completed = subTask.getCompletedAt() != null ? java.sql.Date.valueOf(subTask.getCompletedAt()) : null;
+        jdbcTemplate.update(sql, subTask.getTitle(), deadline, completed, subTask.getId());
+    }
+
+    @Override
+    public void deleteById(int id) {
+        String sql = "DELETE FROM sub_tasks WHERE id = ?";
+        jdbcTemplate.update(sql, id);
+    }
+}

--- a/src/main/java/com/example/demo/service/subtask/SubTaskService.java
+++ b/src/main/java/com/example/demo/service/subtask/SubTaskService.java
@@ -1,0 +1,12 @@
+package com.example.demo.service.subtask;
+
+import java.util.List;
+
+import com.example.demo.entity.SubTask;
+
+public interface SubTaskService {
+    List<SubTask> getSubTasks(int taskId);
+    void addSubTask(SubTask subTask);
+    void updateSubTask(SubTask subTask);
+    void deleteSubTaskById(int id);
+}

--- a/src/main/java/com/example/demo/service/subtask/SubTaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/subtask/SubTaskServiceImpl.java
@@ -1,0 +1,68 @@
+package com.example.demo.service.subtask;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.SubTask;
+import com.example.demo.repository.subtask.SubTaskRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SubTaskServiceImpl implements SubTaskService {
+
+    private final SubTaskRepository repository;
+
+    @Override
+    public List<SubTask> getSubTasks(int taskId) {
+        log.debug("Fetching subtasks for task {}", taskId);
+        List<SubTask> list = repository.findByTaskId(taskId);
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        for (SubTask st : list) {
+            if (st.getCompletedAt() != null) {
+                st.setTimeUntilDue(null);
+                continue;
+            }
+            LocalDateTime deadline = st.getDeadline();
+            if (deadline == null) {
+                st.setExpired(true);
+                st.setTimeUntilDue("-");
+                continue;
+            }
+            long minutes = Duration.between(now, deadline).toMinutes();
+            boolean expired = minutes <= 0;
+            if (minutes < 0) minutes = 0;
+            long days = minutes / (60 * 24);
+            long hours = (minutes % (60 * 24)) / 60;
+            long mins = minutes % 60;
+            st.setTimeUntilDue(String.format("%d日%d時間%d分", days, hours, mins));
+            st.setExpired(expired);
+        }
+        return list;
+    }
+
+    @Override
+    public void addSubTask(SubTask subTask) {
+        log.debug("Adding subtask {}", subTask.getTitle());
+        repository.insertSubTask(subTask);
+    }
+
+    @Override
+    public void updateSubTask(SubTask subTask) {
+        log.debug("Updating subtask id {}", subTask.getId());
+        repository.updateSubTask(subTask);
+    }
+
+    @Override
+    public void deleteSubTaskById(int id) {
+        log.debug("Deleting subtask id {}", id);
+        repository.deleteById(id);
+    }
+}

--- a/src/main/resources/templates/task-page.html
+++ b/src/main/resources/templates/task-page.html
@@ -19,6 +19,24 @@
       <textarea id="task-page-content" rows="20" cols="80" th:text="${page.content}"></textarea>
     </div>
 
+    <div class="database-container">
+      <p>子タスクデータベース</p>
+      <table class="task-database">
+        <tr>
+          <th>子タスク名</th>
+          <th>締切</th>
+          <th>期日</th>
+          <th>完了日</th>
+        </tr>
+        <tr th:each="st : ${subTasks}">
+          <td th:text="${st.title}"></td>
+          <td th:text="${#temporals.format(st.deadline, 'yyyy-MM-dd HH:mm')}"></td>
+          <td th:text="${st.expired ? '期限切れ' : st.timeUntilDue}" th:style="${st.expired} ? 'color:red' : ''"></td>
+          <td th:text="${st.completedAt}"></td>
+        </tr>
+      </table>
+    </div>
+
     <script th:src="@{/js/task-page.js}"></script>
     <!-- task-page.jsで pageIdを使うために-->
     <script th:inline="javascript">


### PR DESCRIPTION
## Summary
- add SubTask entity and repository/service/controller implementation
- extend TaskPageController to load subtasks
- render subtask database on task-page template

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68720ab7ab98832a90cf4ef80029e629