### PR TITLE
Add subtask creation button

### DIFF
--- a/src/main/resources/static/js/task-page.js
+++ b/src/main/resources/static/js/task-page.js
@@ -1,14 +1,26 @@
 document.addEventListener('DOMContentLoaded', () => {
   const textarea = document.getElementById('task-page-content');
-  textarea.addEventListener('change', save);//テクストエリアに記入が完了したら
+  if (textarea) {
+    textarea.addEventListener('change', save);
+  }
 
-  if (!textarea) return;
-  const save = () => {
-    //TaskPageControllerにPOST
+  const newButton = document.getElementById('new-subtask-button');
+  if (newButton) {
+    newButton.addEventListener('click', () => {
+      fetch('/subtask-add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ taskId: taskId, title: '' }),
+        keepalive: true,
+      }).then(() => location.reload());
+    });
+  }
+
+  function save() {
     fetch('/task-page-update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: pageId, content: textarea.value })
     });
-  };
+  }
 });

--- a/src/main/resources/templates/task-page.html
+++ b/src/main/resources/templates/task-page.html
@@ -35,12 +35,14 @@
           <td th:text="${st.completedAt}"></td>
         </tr>
       </table>
+      <button id="new-subtask-button">子タスク新規</button>
     </div>
 
     <script th:src="@{/js/task-page.js}"></script>
     <!-- task-page.jsで pageIdを使うために-->
     <script th:inline="javascript">
       const pageId = [[${page.id}]];
+      const taskId = [[${task.id}]];
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new subtask button on the task page
- expose taskId to JavaScript
- handle the new button via `task-page.js`

## Testing
- `./mvnw -q test` *(fails: could not resolve Spring parent pom)*

------
https://chatgpt.com/codex/tasks/task_e_687210c1f890832aa2227c46c7fe3747