### PR TITLE
Add subtask management features

### DIFF
--- a/src/main/java/com/example/demo/service/task/TaskService.java
+++ b/src/main/java/com/example/demo/service/task/TaskService.java
@@ -14,4 +14,6 @@ public interface TaskService {
     void deleteTaskById(int id);
 
     int getTotalCompletedLevels();
+
+    Task getTaskById(int id);
 }

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -120,4 +120,10 @@ public class TaskServiceImpl implements TaskService {
         log.debug("Fetching total completed task levels");
         return repository.sumCompletedLevels();
     }
+
+    @Override
+    public Task getTaskById(int id) {
+        log.debug("Fetching task by id {}", id);
+        return repository.findById(id);
+    }
 }

--- a/src/main/resources/static/js/task-page.js
+++ b/src/main/resources/static/js/task-page.js
@@ -16,11 +16,72 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  document.querySelectorAll('.subtask-delete-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/subtask-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) }),
+        keepalive: true,
+      }).then(() => location.reload());
+    });
+  });
+
+  document.querySelectorAll('.subtask-complete-button').forEach((btn) => {
+    const row = btn.closest('tr');
+    const comp = row ? row.querySelector('.subtask-completed-input') : null;
+    if (comp && comp.value) {
+      btn.value = '取消';
+    }
+    btn.addEventListener('click', () => {
+      if (!row || !comp) return;
+      if (btn.value === '完了') {
+        comp.value = new Date().toISOString().split('T')[0];
+        btn.value = '取消';
+      } else {
+        comp.value = '';
+        btn.value = '完了';
+      }
+      sendUpdate(row).then(() => location.reload());
+    });
+  });
+
+  document
+    .querySelectorAll('.subtask-title-input, .subtask-completed-input')
+    .forEach((inp) => {
+      inp.addEventListener('change', () => {
+        const row = inp.closest('tr');
+        if (row) sendUpdate(row);
+      });
+    });
+
   function save() {
     fetch('/task-page-update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: pageId, content: textarea.value })
+    });
+  }
+
+  function gatherData(row) {
+    return {
+      id: parseInt(row.dataset.id, 10),
+      title: row.querySelector('.subtask-title-input').value,
+      deadline: row.dataset.deadline || null,
+      completedAt: row.querySelector('.subtask-completed-input').value || null,
+    };
+  }
+
+  function sendUpdate(row) {
+    const data = gatherData(row);
+    return fetch('/subtask-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+      keepalive: true,
     });
   }
 });

--- a/src/main/resources/templates/task-page.html
+++ b/src/main/resources/templates/task-page.html
@@ -23,16 +23,20 @@
       <p>子タスクデータベース</p>
       <table class="task-database">
         <tr>
+          <th>完了</th>
+          <th>削除</th>
           <th>子タスク名</th>
           <th>締切</th>
           <th>期日</th>
           <th>完了日</th>
         </tr>
-        <tr th:each="st : ${subTasks}">
-          <td th:text="${st.title}"></td>
+        <tr th:each="st : ${subTasks}" class="subtask-row" th:data-id="${st.id}" th:data-deadline="${#temporals.format(st.deadline, 'yyyy-MM-dd\'T\'HH:mm')}">
+          <td><input type="button" value="完了" class="subtask-complete-button" /></td>
+          <td><input type="button" value="削除" class="subtask-delete-button" /></td>
+          <td><input type="text" th:value="${st.title}" class="subtask-title-input" /></td>
           <td th:text="${#temporals.format(st.deadline, 'yyyy-MM-dd HH:mm')}"></td>
           <td th:text="${st.expired ? '期限切れ' : st.timeUntilDue}" th:style="${st.expired} ? 'color:red' : ''"></td>
-          <td th:text="${st.completedAt}"></td>
+          <td><input type="date" th:value="${st.completedAt}" class="subtask-completed-input" /></td>
         </tr>
       </table>
       <button id="new-subtask-button">子タスク新規</button>


### PR DESCRIPTION
## Summary
- expose task lookup by ID in `TaskService`
- update `SubTaskServiceImpl` to copy parent deadline and support updates
- enhance subtask table with editable name, completion and delete buttons
- extend page script to manage subtasks

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6872129cd21c832a887b53d978c4920a