### PR TITLE
Show completed subtasks separately

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskPageController.java
+++ b/src/main/java/com/example/demo/controller/TaskPageController.java
@@ -41,7 +41,15 @@ public class TaskPageController {
                 .filter(t -> t.getId() == taskId)
                 .findFirst()
                 .orElse(null);
-        model.addAttribute("subTasks", subTaskService.getSubTasks(taskId));
+        var allSubTasks = subTaskService.getSubTasks(taskId);
+        var uncompleted = allSubTasks.stream()
+                .filter(st -> st.getCompletedAt() == null)
+                .toList();
+        var completed = allSubTasks.stream()
+                .filter(st -> st.getCompletedAt() != null)
+                .toList();
+        model.addAttribute("uncompletedSubTasks", uncompleted);
+        model.addAttribute("completedSubTasks", completed);
         model.addAttribute("page", page);
         model.addAttribute("task", task);
         model.addAttribute("username", username);

--- a/src/main/resources/templates/task-page.html
+++ b/src/main/resources/templates/task-page.html
@@ -19,9 +19,10 @@
       <textarea id="task-page-content" rows="20" cols="80" th:text="${page.content}"></textarea>
     </div>
 
-    <div class="database-container">
-      <p>子タスクデータベース</p>
-      <table class="task-database">
+    <div class="database-row">
+      <div class="database-container">
+        <p>未完了子タスク</p>
+        <table id="uncompleted-subtask-table" class="task-database">
         <tr>
           <th>完了</th>
           <th>削除</th>
@@ -30,7 +31,7 @@
           <th>期日</th>
           <th>完了日</th>
         </tr>
-        <tr th:each="st : ${subTasks}" class="subtask-row" th:data-id="${st.id}" th:data-deadline="${#temporals.format(st.deadline, 'yyyy-MM-dd''T''HH:mm')}">
+        <tr th:each="st : ${uncompletedSubTasks}" class="subtask-row" th:data-id="${st.id}" th:data-deadline="${#temporals.format(st.deadline, 'yyyy-MM-dd''T''HH:mm')}">
           <td><input type="button" value="完了" class="subtask-complete-button" /></td>
           <td><input type="button" value="削除" class="subtask-delete-button" /></td>
           <td><input type="text" th:value="${st.title}" class="subtask-title-input" /></td>
@@ -38,8 +39,30 @@
           <td th:text="${st.expired ? '期限切れ' : st.timeUntilDue}" th:style="${st.expired} ? 'color:red' : ''"></td>
           <td><input type="date" th:value="${st.completedAt}" class="subtask-completed-input" /></td>
         </tr>
-      </table>
-      <button id="new-subtask-button">子タスク新規</button>
+        </table>
+        <button id="new-subtask-button">子タスク新規</button>
+      </div>
+      <div class="database-container">
+        <p>完了済み子タスク</p>
+        <table id="completed-subtask-table" class="task-database">
+          <tr>
+            <th>完了</th>
+            <th>削除</th>
+            <th>子タスク名</th>
+            <th>締切</th>
+            <th>期日</th>
+            <th>完了日</th>
+          </tr>
+          <tr th:each="st : ${completedSubTasks}" class="subtask-row" th:data-id="${st.id}" th:data-deadline="${#temporals.format(st.deadline, 'yyyy-MM-dd''T''HH:mm')}">
+            <td><input type="button" value="取消" class="subtask-complete-button" /></td>
+            <td><input type="button" value="削除" class="subtask-delete-button" /></td>
+            <td><input type="text" th:value="${st.title}" class="subtask-title-input" /></td>
+            <td th:text="${#temporals.format(st.deadline, 'yyyy-MM-dd HH:mm')}"></td>
+            <td th:text="${st.expired ? '期限切れ' : st.timeUntilDue}" th:style="${st.expired} ? 'color:red' : ''"></td>
+            <td><input type="date" th:value="${st.completedAt}" class="subtask-completed-input" /></td>
+          </tr>
+        </table>
+      </div>
     </div>
 
     <script th:src="@{/js/task-page.js}"></script>


### PR DESCRIPTION
## Summary
- split subtasks into completed and uncompleted lists in `TaskPageController`
- update `task-page.html` to show two subtask tables side-by-side

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687217d067c4832a812e53cd1b1b65ab