### PR TITLE
Update progress when completing or cancelling tasks

### DIFF
--- a/src/main/java/com/example/demo/repository/subtask/SubTaskRepository.java
+++ b/src/main/java/com/example/demo/repository/subtask/SubTaskRepository.java
@@ -19,4 +19,11 @@ public interface SubTaskRepository {
      * @param completedAt 完了日
      */
     void markAllCompletedByTaskId(int taskId, java.time.LocalDate completedAt);
+
+    /**
+     * 指定したタスクIDの子タスクをすべて未完了状態に戻す。
+     *
+     * @param taskId 親タスクのID
+     */
+    void markAllUncompletedByTaskId(int taskId);
 }

--- a/src/main/java/com/example/demo/repository/subtask/SubTaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/subtask/SubTaskRepositoryImpl.java
@@ -85,4 +85,10 @@ public class SubTaskRepositoryImpl implements SubTaskRepository {
         java.sql.Date completed = completedAt != null ? java.sql.Date.valueOf(completedAt) : null;
         jdbcTemplate.update(sql, completed, taskId);
     }
+
+    @Override
+    public void markAllUncompletedByTaskId(int taskId) {
+        String sql = "UPDATE sub_tasks SET completed_at = NULL WHERE task_id = ?";
+        jdbcTemplate.update(sql, taskId);
+    }
 }

--- a/src/main/java/com/example/demo/service/subtask/SubTaskService.java
+++ b/src/main/java/com/example/demo/service/subtask/SubTaskService.java
@@ -19,4 +19,11 @@ public interface SubTaskService {
      * @param completedAt 完了日
      */
     void markAllCompletedByTaskId(int taskId, java.time.LocalDate completedAt);
+
+    /**
+     * 親タスクの子タスクをすべて未完了に戻す。
+     *
+     * @param taskId 親タスクのID
+     */
+    void markAllUncompletedByTaskId(int taskId);
 }

--- a/src/main/java/com/example/demo/service/subtask/SubTaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/subtask/SubTaskServiceImpl.java
@@ -106,4 +106,10 @@ public class SubTaskServiceImpl implements SubTaskService {
         log.debug("Marking all subtasks of task {} completed", taskId);
         repository.markAllCompletedByTaskId(taskId, completedAt);
     }
+
+    @Override
+    public void markAllUncompletedByTaskId(int taskId) {
+        log.debug("Marking all subtasks of task {} uncompleted", taskId);
+        repository.markAllUncompletedByTaskId(taskId);
+    }
 }

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -121,6 +121,8 @@ public class TaskServiceImpl implements TaskService {
         boolean isCompleted = task.getCompletedAt() != null;
         if (!wasCompleted && isCompleted) {
             subTaskRepository.markAllCompletedByTaskId(task.getId(), task.getCompletedAt());
+        } else if (wasCompleted && !isCompleted) {
+            subTaskRepository.markAllUncompletedByTaskId(task.getId());
         }
     }
 

--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -46,24 +46,28 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', () => {
       if (!row || !comp) return;
       //もし完了ボタンを押したら
-      if (btn.value === '完了') {
-        comp.value = new Date().toISOString().split('T')[0];//完了日を入れる
-        btn.value = '取消';
-        moveRow(row, true);//完了済みに移動させる
-        const expiration=row ? row.querySelector('.task-completed-input') : null;
-        const diffCell = row.cells[6];//期日を取得
-        if (diffCell) diffCell.textContent = '';//期日をnull
-        sortAllTaskTables();//締切が速い順に並び替え
-      } else {
-        comp.value = '';
-        btn.value = '完了';
-        moveRow(row, false);//未完了に移動させる
-        updateTimeUntilDue(row);//期日を再計算，期日は区分に依存している
-        sortAllTaskTables();//締切が速い順に
-      }
-    sendUpdate(row).then(refreshTotalPoint);//サーバーサイドのデータベース更新＆ポイント更新
+        if (btn.value === '完了') {
+          comp.value = new Date().toISOString().split('T')[0];//完了日を入れる
+          btn.value = '取消';
+          moveRow(row, true);//完了済みに移動させる
+          const expiration=row ? row.querySelector('.task-completed-input') : null;
+          const diffCell = row.cells[6];//期日を取得
+          if (diffCell) diffCell.textContent = '';//期日をnull
+          const progCell = row.cells[7];
+          if (progCell) progCell.textContent = '100%';
+          sortAllTaskTables();//締切が速い順に並び替え
+        } else {
+          comp.value = '';
+          btn.value = '完了';
+          moveRow(row, false);//未完了に移動させる
+          updateTimeUntilDue(row);//期日を再計算，期日は区分に依存している
+          const progCell = row.cells[7];
+          if (progCell) progCell.textContent = '0%';
+          sortAllTaskTables();//締切が速い順に
+        }
+      sendUpdate(row).then(refreshTotalPoint);//サーバーサイドのデータベース更新＆ポイント更新
+    });
   });
-});
 
   //完了日の入力欄が直接変更されたときの処理
   document.querySelectorAll('.task-completed-input').forEach((inp) => {
@@ -72,16 +76,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const handler = () => {
       if (!row || !btn) return;
       //すでに完了日に日付入っているなら
-      if (inp.value) {
-        btn.value = '取消';
-        moveRow(row, true);//完了済みテーブルに移動,top画面なら非表示に
-        const diffCell = row.cells[6];
-        if (diffCell) diffCell.textContent = '';//期日をnullに
-      } else {
-        btn.value = '完了';
-        moveRow(row, false);//未完了テーブルに移動
-        updateTimeUntilDue(row);//区分から締切を，締切から期日を作成
-      }
+        if (inp.value) {
+          btn.value = '取消';
+          moveRow(row, true);//完了済みテーブルに移動,top画面なら非表示に
+          const diffCell = row.cells[6];
+          if (diffCell) diffCell.textContent = '';//期日をnullに
+          const progCell = row.cells[7];
+          if (progCell) progCell.textContent = '100%';
+        } else {
+          btn.value = '完了';
+          moveRow(row, false);//未完了テーブルに移動
+          updateTimeUntilDue(row);//区分から締切を，締切から期日を作成
+          const progCell = row.cells[7];
+          if (progCell) progCell.textContent = '0%';
+        }
       sortAllTaskTables();//締切が速い順に
       sendUpdate(row).then(refreshTotalPoint);//サーバサイドのデータベースを更新した後に，ポイントも更新
     };


### PR DESCRIPTION
## Summary
- make repository method to undo subtask completion
- support resetting progress when a task is cancelled
- update front-end progress display immediately when completing or cancelling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68722359a6f8832a91939b0cc244c061