### PR TITLE
Fix task progress revert when cancelled

### DIFF
--- a/src/main/resources/static/js/task.js
+++ b/src/main/resources/static/js/task.js
@@ -62,7 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
           moveRow(row, false);//未完了に移動させる
           updateTimeUntilDue(row);//期日を再計算，期日は区分に依存している
           const progCell = row.cells[7];
-          if (progCell) progCell.textContent = '0%';
+          if (progCell) progCell.textContent = row.dataset.progressNull === 'true' ? '' : '0%';
           sortAllTaskTables();//締切が速い順に
         }
       sendUpdate(row).then(refreshTotalPoint);//サーバーサイドのデータベース更新＆ポイント更新
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
           moveRow(row, false);//未完了テーブルに移動
           updateTimeUntilDue(row);//区分から締切を，締切から期日を作成
           const progCell = row.cells[7];
-          if (progCell) progCell.textContent = '0%';
+          if (progCell) progCell.textContent = row.dataset.progressNull === 'true' ? '' : '0%';
         }
       sortAllTaskTables();//締切が速い順に
       sendUpdate(row).then(refreshTotalPoint);//サーバサイドのデータベースを更新した後に，ポイントも更新

--- a/src/main/resources/templates/task-box.html
+++ b/src/main/resources/templates/task-box.html
@@ -25,7 +25,7 @@
           <th>レベル</th>
           <th>完了日</th>
         </tr>
-        <tr th:each="task : ${uncompletedTasks}" class="task-row" th:data-id="${task.id}">
+          <tr th:each="task : ${uncompletedTasks}" class="task-row" th:data-id="${task.id}" th:data-progress-null="${task.progressRate == null}">
           <td><input type="button" value="完了" class="task-complete-button" /></td>
           <td><input type="button" value="削除" class="task-delete-button" /></td>
           <td><a th:href="@{'/' + ${username} + '/task-top/task-page/' + ${task.id}}">go</a></td>
@@ -70,7 +70,7 @@
           <th>レベル</th>
           <th>完了日</th>
         </tr>
-        <tr th:each="task : ${completedTasks}" class="task-row" th:data-id="${task.id}">
+          <tr th:each="task : ${completedTasks}" class="task-row" th:data-id="${task.id}" th:data-progress-null="${task.progressRate == null}">
           <td><input type="button" value="取消" class="task-complete-button" /></td>
           <td><input type="button" value="削除" class="task-delete-button" /></td>
           <td><a th:href="@{'/' + ${username} + '/task-top/task-page/' + ${task.id}}">go</a></td>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -153,7 +153,7 @@
           <th>レベル</th>
           <th>完了日</th>
         </tr>
-        <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}">
+        <tr th:each="task : ${tasks}" class="task-row" th:data-id="${task.id}" th:data-progress-null="${task.progressRate == null}">
           <td><input type="button" value="完了" class="task-complete-button" /></td>
           <td><input type="button" value="削除" class="task-delete-button" /></td>
           <td><a th:href="@{'/' + ${username} + '/task-top/task-page/' + ${task.id}}">go</a></td>


### PR DESCRIPTION
## Summary
- add a `data-progress-null` attribute in task rows
- show an empty progress field on cancel when there was no progress value originally

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68722d40dcdc832aa1852e666a223ff7