### PR TITLE
Filter tasks completed by subtasks

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -48,6 +48,7 @@ public class TopController {
         model.addAttribute("challenges", challengeList);
         var taskList = taskService.getAllTasks().stream()
                 .filter(t -> t.getCompletedAt() == null)
+                .filter(t -> !"100%".equals(t.getProgressRate()))
                 .toList();
         model.addAttribute("tasks", taskList);
         var awarenessList = awarenessRecordService.getAllRecords()
@@ -114,9 +115,10 @@ public class TopController {
         var all = taskService.getAllTasks();
         var uncompleted = all.stream()
                 .filter(t -> t.getCompletedAt() == null)
+                .filter(t -> !"100%".equals(t.getProgressRate()))
                 .toList();
         var completedTasks = all.stream()
-                .filter(t -> t.getCompletedAt() != null)
+                .filter(t -> t.getCompletedAt() != null || "100%".equals(t.getProgressRate()))
                 .toList();
         model.addAttribute("uncompletedTasks", uncompleted);
         model.addAttribute("completedTasks", completedTasks);


### PR DESCRIPTION
## Summary
- skip tasks with a 100% progress rate on the top page
- show 100% progress tasks in the completed section of the task box

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687241839940832abf04c5fe671d43a6