### PR TITLE
Fix progress-based task categorization

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -47,8 +47,10 @@ public class TopController {
                 .toList();
         model.addAttribute("challenges", challengeList);
         var taskList = taskService.getAllTasks().stream()
-                .filter(t -> t.getCompletedAt() == null)
-                .filter(t -> !"100%".equals(t.getProgressRate()))
+                .filter(t -> t.getCompletedAt() == null
+                        || (t.getCompletedAt() != null
+                                && t.getProgressRate() != null
+                                && !"100%".equals(t.getProgressRate())))
                 .toList();
         model.addAttribute("tasks", taskList);
         var awarenessList = awarenessRecordService.getAllRecords()
@@ -114,11 +116,15 @@ public class TopController {
         log.debug("Displaying task box page");
         var all = taskService.getAllTasks();
         var uncompleted = all.stream()
-                .filter(t -> t.getCompletedAt() == null)
-                .filter(t -> !"100%".equals(t.getProgressRate()))
+                .filter(t -> t.getCompletedAt() == null
+                        || (t.getCompletedAt() != null
+                                && t.getProgressRate() != null
+                                && !"100%".equals(t.getProgressRate())))
                 .toList();
         var completedTasks = all.stream()
-                .filter(t -> t.getCompletedAt() != null || "100%".equals(t.getProgressRate()))
+                .filter(t -> t.getCompletedAt() != null
+                        && (t.getProgressRate() == null
+                                || "100%".equals(t.getProgressRate())))
                 .toList();
         model.addAttribute("uncompletedTasks", uncompleted);
         model.addAttribute("completedTasks", completedTasks);


### PR DESCRIPTION
## Summary
- refine task filtering logic so that completed tasks with progress <100% appear in the uncompleted list unless progress is null

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_687245475454832a96b7b5c485f1ec89