### PR TITLE
Refine completed task filtering

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -45,8 +45,9 @@ public class TopController {
                 .toList();
         model.addAttribute("challenges", challengeList);
         var taskList = taskService.getAllTasks().stream()
-        		.filter(t -> t.getCompletedAt() == null)
-                .filter(t -> !"100%".equals(t.getProgressRate()))
+                        .filter(t -> !(t.getCompletedAt() != null
+                                && ("100%".equals(t.getProgressRate())
+                                        || t.getProgressRate() == null)))
                 .toList();
         model.addAttribute("tasks", taskList);
         var awarenessList = awarenessRecordService.getAllRecords()
@@ -111,12 +112,14 @@ public class TopController {
         }
         log.debug("Displaying task box page");
         var all = taskService.getAllTasks();
-        var uncompleted = all.stream()
-        		.filter(t -> t.getCompletedAt() == null)
-                .filter(t -> !"100%".equals(t.getProgressRate()))
-                .toList();
         var completedTasks = all.stream()
-        		.filter(t -> t.getCompletedAt() != null || "100%".equals(t.getProgressRate()))
+                        .filter(t -> t.getCompletedAt() != null)
+                        .filter(t -> "100%".equals(t.getProgressRate()) || t.getProgressRate() == null)
+                .toList();
+        var uncompleted = all.stream()
+                        .filter(t -> !(t.getCompletedAt() != null
+                                && ("100%".equals(t.getProgressRate())
+                                        || t.getProgressRate() == null)))
                 .toList();
         model.addAttribute("uncompletedTasks", uncompleted);
         model.addAttribute("completedTasks", completedTasks);


### PR DESCRIPTION
## Summary
- update the task filtering rules
- only show completed tasks when progress rate is 100% or null
- adjust uncompleted task lists accordingly

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687251c91820832a9429439637aa6e34