### PR TITLE
Fix subtask cancel

### DIFF
--- a/src/main/resources/static/js/task-page.js
+++ b/src/main/resources/static/js/task-page.js
@@ -72,6 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
       title: row.querySelector('.subtask-title-input').value,
       deadline: row.dataset.deadline || null,
       completedAt: row.querySelector('.subtask-completed-input').value || null,
+      taskId: taskId,
     };
   }
 


### PR DESCRIPTION
## Summary
- update `gatherData` in **task-page.js** so the subtask update API gets the parent task id

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68725c12db3c832a90dce228849afec3