### PR TITLE
Prevent completed subtasks from being reset when adding new one

### DIFF
--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -94,13 +94,15 @@ public class TaskServiceImpl implements TaskService {
                 if (completed == total) {
                     if (t.getCompletedAt() == null) {
                         t.setCompletedAt(LocalDate.now());
-                        updateTask(t);
+                        // Update parent task only to avoid changing subtask status
+                        repository.updateTask(t);
                     }
                 } else {
                     // Some subtasks remain -> clear completion date if set
                     if (t.getCompletedAt() != null) {
                         t.setCompletedAt(null);
-                        updateTask(t);
+                        // Update parent task only to avoid changing subtask status
+                        repository.updateTask(t);
                     }
                 }
             } else {
@@ -167,12 +169,14 @@ public class TaskServiceImpl implements TaskService {
             if (completed == total) {
                 if (t.getCompletedAt() == null) {
                     t.setCompletedAt(LocalDate.now());
-                    updateTask(t);
+                    // Update parent task only to avoid modifying subtasks
+                    repository.updateTask(t);
                 }
             } else {
                 if (t.getCompletedAt() != null) {
                     t.setCompletedAt(null);
-                    updateTask(t);
+                    // Update parent task only to avoid modifying subtasks
+                    repository.updateTask(t);
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- fix `TaskServiceImpl` so automatic task completion syncing updates only the parent task

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687261484260832a85a5f5b770f3721d