### PR TITLE
Implement SubTask box page

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -12,6 +12,7 @@ import com.example.demo.service.awareness.AwarenessRecordService;
 import com.example.demo.service.challenge.ChallengeService;
 import com.example.demo.service.schedule.ScheduleService;
 import com.example.demo.service.task.TaskService;
+import com.example.demo.service.subtask.SubTaskService;
 import com.example.demo.service.word.WordRecordService;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class TopController {
     private final ScheduleService scheduleService;
     private final ChallengeService challengeService;
     private final TaskService taskService;
+    private final SubTaskService subTaskService;
     private final AwarenessRecordService awarenessRecordService;
     private final WordRecordService wordRecordService;
 
@@ -151,6 +153,26 @@ public class TopController {
         model.addAttribute("wordRecords", records);
         model.addAttribute("username", username);
         return "word-box";
+    }
+
+    @GetMapping("/{username}/task-top/sub-task-box")
+    public String showSubTaskBox(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying sub task box page");
+        var all = subTaskService.getAllSubTasks();
+        var uncompleted = all.stream()
+                .filter(st -> st.getCompletedAt() == null)
+                .toList();
+        var completed = all.stream()
+                .filter(st -> st.getCompletedAt() != null)
+                .toList();
+        model.addAttribute("uncompletedSubTasks", uncompleted);
+        model.addAttribute("completedSubTasks", completed);
+        model.addAttribute("username", username);
+        return "sub-task-box";
     }
     //-------------------------------------------------------------------------------------------------
     @GetMapping("/total-point")

--- a/src/main/java/com/example/demo/repository/subtask/SubTaskRepository.java
+++ b/src/main/java/com/example/demo/repository/subtask/SubTaskRepository.java
@@ -5,6 +5,11 @@ import java.util.List;
 import com.example.demo.entity.SubTask;
 
 public interface SubTaskRepository {
+    /**
+     * 全ての子タスクを取得する。
+     * @return 子タスク一覧
+     */
+    List<SubTask> findAll();
     List<SubTask> findByTaskId(int taskId);
     void insertSubTask(SubTask subTask);
     void updateSubTask(SubTask subTask);

--- a/src/main/java/com/example/demo/repository/subtask/SubTaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/subtask/SubTaskRepositoryImpl.java
@@ -38,6 +38,12 @@ public class SubTaskRepositoryImpl implements SubTaskRepository {
     };
 
     @Override
+    public List<SubTask> findAll() {
+        String sql = "SELECT id, task_id, title, deadline, completed_at FROM sub_tasks ORDER BY id";
+        return jdbcTemplate.query(sql, ROW_MAPPER);
+    }
+
+    @Override
     public List<SubTask> findByTaskId(int taskId) {
         String sql = "SELECT id, task_id, title, deadline, completed_at FROM sub_tasks WHERE task_id = ? ORDER BY id";
         return jdbcTemplate.query(sql, ROW_MAPPER, taskId);

--- a/src/main/java/com/example/demo/service/subtask/SubTaskService.java
+++ b/src/main/java/com/example/demo/service/subtask/SubTaskService.java
@@ -5,6 +5,11 @@ import java.util.List;
 import com.example.demo.entity.SubTask;
 
 public interface SubTaskService {
+    /**
+     * すべての子タスクを取得する。
+     * @return 子タスク一覧
+     */
+    List<SubTask> getAllSubTasks();
     List<SubTask> getSubTasks(int taskId);
     void addSubTask(SubTask subTask);
     void updateSubTask(SubTask subTask);

--- a/src/main/resources/static/js/subtask.js
+++ b/src/main/resources/static/js/subtask.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.subtask-delete-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/subtask-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) }),
+        keepalive: true,
+      }).then(() => location.reload());
+    });
+  });
+
+  document.querySelectorAll('.subtask-complete-button').forEach((btn) => {
+    const row = btn.closest('tr');
+    const comp = row ? row.querySelector('.subtask-completed-input') : null;
+    if (comp && comp.value) {
+      btn.value = '取消';
+    }
+    btn.addEventListener('click', () => {
+      if (!row || !comp) return;
+      if (btn.value === '完了') {
+        comp.value = new Date().toISOString().split('T')[0];
+        btn.value = '取消';
+      } else {
+        comp.value = '';
+        btn.value = '完了';
+      }
+      sendUpdate(row).then(() => location.reload());
+    });
+  });
+
+  document
+    .querySelectorAll('.subtask-title-input, .subtask-completed-input')
+    .forEach((inp) => {
+      inp.addEventListener('change', () => {
+        const row = inp.closest('tr');
+        if (row) sendUpdate(row);
+      });
+    });
+
+  function gatherData(row) {
+    return {
+      id: parseInt(row.dataset.id, 10),
+      title: row.querySelector('.subtask-title-input').value,
+      deadline: row.dataset.deadline || null,
+      completedAt: row.querySelector('.subtask-completed-input').value || null,
+      taskId: parseInt(row.dataset.taskId, 10),
+    };
+  }
+
+  function sendUpdate(row) {
+    const data = gatherData(row);
+    return fetch('/subtask-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+      keepalive: true,
+    });
+  }
+});

--- a/src/main/resources/templates/sub-task-box.html
+++ b/src/main/resources/templates/sub-task-box.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>子タスクボックス</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+    </div>
+
+    <div class="database-container">
+      <p>未完了子タスク</p>
+      <table id="uncompleted-subtask-table" class="task-database">
+        <tr>
+          <th>完了</th>
+          <th>削除</th>
+          <th>親ID</th>
+          <th>子タスク名</th>
+          <th>締切</th>
+          <th>期日</th>
+          <th>完了日</th>
+        </tr>
+        <tr th:each="st : ${uncompletedSubTasks}" class="subtask-row" th:data-id="${st.id}" th:data-task-id="${st.taskId}" th:data-deadline="${#temporals.format(st.deadline, 'yyyy-MM-dd''T''HH:mm')}">
+          <td><input type="button" value="完了" class="subtask-complete-button" /></td>
+          <td><input type="button" value="削除" class="subtask-delete-button" /></td>
+          <td th:text="${st.taskId}"></td>
+          <td><input type="text" th:value="${st.title}" class="subtask-title-input" /></td>
+          <td th:text="${#temporals.format(st.deadline, 'yyyy-MM-dd HH:mm')}"></td>
+          <td th:text="${st.expired ? '期限切れ' : st.timeUntilDue}" th:style="${st.expired} ? 'color:red' : ''"></td>
+          <td><input type="date" th:value="${st.completedAt}" class="subtask-completed-input" /></td>
+        </tr>
+      </table>
+    </div>
+
+    <div class="database-container">
+      <p>完了済み子タスク</p>
+      <table id="completed-subtask-table" class="task-database">
+        <tr>
+          <th>完了</th>
+          <th>削除</th>
+          <th>親ID</th>
+          <th>子タスク名</th>
+          <th>締切</th>
+          <th>期日</th>
+          <th>完了日</th>
+        </tr>
+        <tr th:each="st : ${completedSubTasks}" class="subtask-row" th:data-id="${st.id}" th:data-task-id="${st.taskId}" th:data-deadline="${#temporals.format(st.deadline, 'yyyy-MM-dd''T''HH:mm')}">
+          <td><input type="button" value="取消" class="subtask-complete-button" /></td>
+          <td><input type="button" value="削除" class="subtask-delete-button" /></td>
+          <td th:text="${st.taskId}"></td>
+          <td><input type="text" th:value="${st.title}" class="subtask-title-input" /></td>
+          <td th:text="${#temporals.format(st.deadline, 'yyyy-MM-dd HH:mm')}"></td>
+          <td th:text="${st.expired ? '期限切れ' : st.timeUntilDue}" th:style="${st.expired} ? 'color:red' : ''"></td>
+          <td><input type="date" th:value="${st.completedAt}" class="subtask-completed-input" /></td>
+        </tr>
+      </table>
+    </div>
+
+    <script th:src="@{/js/subtask.js}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new SubTask box page showing all subtasks
- list subtasks split into uncompleted and completed sections
- support updating subtasks via new JavaScript
- expose `getAllSubTasks()` through service and repository
- wire the new page through `TopController`

## Testing
- `mvn -q test` *(fails: Could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6872691f2c54832a931eccbd99afa471