### PR TITLE
Sort subtasks by date

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -165,9 +165,15 @@ public class TopController {
         var all = subTaskService.getAllSubTasks();
         var uncompleted = all.stream()
                 .filter(st -> st.getCompletedAt() == null)
+                .sorted(java.util.Comparator.comparing(
+                        com.example.demo.entity.SubTask::getDeadline,
+                        java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
                 .toList();
         var completed = all.stream()
                 .filter(st -> st.getCompletedAt() != null)
+                .sorted(java.util.Comparator.comparing(
+                        com.example.demo.entity.SubTask::getDeadline,
+                        java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
                 .toList();
         model.addAttribute("uncompletedSubTasks", uncompleted);
         model.addAttribute("completedSubTasks", completed);

--- a/src/main/java/com/example/demo/service/subtask/SubTaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/subtask/SubTaskServiceImpl.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Comparator;
 
 import org.springframework.stereotype.Service;
 
@@ -59,7 +60,9 @@ public class SubTaskServiceImpl implements SubTaskService {
                 }
             }
             return st;
-        }).toList();
+        }).sorted(Comparator.comparing(SubTask::getDeadline,
+                Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
     }
 
     @Override
@@ -96,7 +99,10 @@ public class SubTaskServiceImpl implements SubTaskService {
             st.setTimeUntilDue(String.format("%d日%d時間%d分", days, hours, mins));
             st.setExpired(expired);
         }
-        return list;
+        return list.stream()
+                .sorted(Comparator.comparing(SubTask::getDeadline,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- order subtasks by earliest deadline in subtask box
- keep service methods returning subtasks sorted by deadline

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68727048f5e8832a88a098f84fe658e0