### PR TITLE
Add dream database feature

### DIFF
--- a/src/main/java/com/example/demo/controller/DreamRecordController.java
+++ b/src/main/java/com/example/demo/controller/DreamRecordController.java
@@ -1,0 +1,41 @@
+package com.example.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.DreamRecord;
+import com.example.demo.service.dream.DreamRecordService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class DreamRecordController {
+
+    private final DreamRecordService service;
+
+    @PostMapping("/dream-add")
+    public ResponseEntity<Void> addRecord(@RequestBody DreamRecord record) {
+        log.debug("Adding dream record");
+        service.addRecord(record);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/dream-update")
+    public ResponseEntity<Void> updateRecord(@RequestBody DreamRecord record) {
+        log.debug("Updating dream record id {}", record.getId());
+        service.updateRecord(record);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/dream-delete")
+    public ResponseEntity<Void> deleteRecord(@RequestBody DreamRecord record) {
+        log.debug("Deleting dream record id {}", record.getId());
+        service.deleteById(record.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -14,6 +14,7 @@ import com.example.demo.service.schedule.ScheduleService;
 import com.example.demo.service.task.TaskService;
 import com.example.demo.service.subtask.SubTaskService;
 import com.example.demo.service.word.WordRecordService;
+import com.example.demo.service.dream.DreamRecordService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ public class TopController {
     private final SubTaskService subTaskService;
     private final AwarenessRecordService awarenessRecordService;
     private final WordRecordService wordRecordService;
+    private final DreamRecordService dreamRecordService;
 
     @GetMapping("/{username}/task-top")
     public String showTaskTop(@PathVariable String username, Model model, HttpSession session) {
@@ -62,6 +64,11 @@ public class TopController {
                 .limit(5)
                 .toList();
         model.addAttribute("wordRecords", wordList);
+        var dreamList = dreamRecordService.getAllRecords()
+                .stream()
+                .limit(5)
+                .toList();
+        model.addAttribute("dreamRecords", dreamList);
         model.addAttribute("username", username);
         return "task-top";
     }
@@ -153,6 +160,19 @@ public class TopController {
         model.addAttribute("wordRecords", records);
         model.addAttribute("username", username);
         return "word-box";
+    }
+
+    @GetMapping("/{username}/task-top/dream-box")
+    public String showDreamBox(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying dream box page");
+        var records = dreamRecordService.getAllRecords();
+        model.addAttribute("dreamRecords", records);
+        model.addAttribute("username", username);
+        return "dream-box";
     }
 
     @GetMapping("/{username}/task-top/sub-task-box")

--- a/src/main/java/com/example/demo/entity/DreamRecord.java
+++ b/src/main/java/com/example/demo/entity/DreamRecord.java
@@ -1,0 +1,10 @@
+package com.example.demo.entity;
+
+import lombok.Data;
+
+@Data
+public class DreamRecord {
+    private int id; // 自動採番ID
+    private String dream; // 夢
+    private String page; // ページ内容
+}

--- a/src/main/java/com/example/demo/repository/dream/DreamRecordRepository.java
+++ b/src/main/java/com/example/demo/repository/dream/DreamRecordRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository.dream;
+
+import java.util.List;
+import com.example.demo.entity.DreamRecord;
+
+public interface DreamRecordRepository {
+    List<DreamRecord> findAll();
+    void insertRecord(DreamRecord record);
+    void updateRecord(DreamRecord record);
+    void deleteById(int id);
+}

--- a/src/main/java/com/example/demo/repository/dream/DreamRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/dream/DreamRecordRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.example.demo.repository.dream;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.DreamRecord;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DreamRecordRepositoryImpl implements DreamRecordRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<DreamRecord> findAll() {
+        String sql = "SELECT id, dream, page FROM dream_records ORDER BY id DESC";
+        return jdbcTemplate.query(sql, new RowMapper<DreamRecord>() {
+            @Override
+            public DreamRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
+                DreamRecord r = new DreamRecord();
+                r.setId(rs.getInt("id"));
+                r.setDream(rs.getString("dream"));
+                r.setPage(rs.getString("page"));
+                return r;
+            }
+        });
+    }
+
+    @Override
+    public void insertRecord(DreamRecord record) {
+        String sql = "INSERT INTO dream_records (dream, page) VALUES (?, ?)";
+        jdbcTemplate.update(sql, record.getDream(), record.getPage());
+    }
+
+    @Override
+    public void updateRecord(DreamRecord record) {
+        String sql = "UPDATE dream_records SET dream = ?, page = ? WHERE id = ?";
+        jdbcTemplate.update(sql, record.getDream(), record.getPage(), record.getId());
+    }
+
+    @Override
+    public void deleteById(int id) {
+        String sql = "DELETE FROM dream_records WHERE id = ?";
+        jdbcTemplate.update(sql, id);
+    }
+}

--- a/src/main/java/com/example/demo/service/dream/DreamRecordService.java
+++ b/src/main/java/com/example/demo/service/dream/DreamRecordService.java
@@ -1,0 +1,11 @@
+package com.example.demo.service.dream;
+
+import java.util.List;
+import com.example.demo.entity.DreamRecord;
+
+public interface DreamRecordService {
+    List<DreamRecord> getAllRecords();
+    void addRecord(DreamRecord record);
+    void updateRecord(DreamRecord record);
+    void deleteById(int id);
+}

--- a/src/main/java/com/example/demo/service/dream/DreamRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/dream/DreamRecordServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.demo.service.dream;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.DreamRecord;
+import com.example.demo.repository.dream.DreamRecordRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DreamRecordServiceImpl implements DreamRecordService {
+
+    private final DreamRecordRepository repository;
+
+    @Override
+    public List<DreamRecord> getAllRecords() {
+        log.debug("Fetching all dream records");
+        return repository.findAll();
+    }
+
+    @Override
+    public void addRecord(DreamRecord record) {
+        log.debug("Adding dream record");
+        repository.insertRecord(record);
+    }
+
+    @Override
+    public void updateRecord(DreamRecord record) {
+        log.debug("Updating dream record id {}", record.getId());
+        repository.updateRecord(record);
+    }
+
+    @Override
+    public void deleteById(int id) {
+        log.debug("Deleting dream record id {}", id);
+        repository.deleteById(id);
+    }
+}

--- a/src/main/resources/static/js/dream.js
+++ b/src/main/resources/static/js/dream.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // 新規夢ボタン
+  document.querySelectorAll('#new-dream-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      fetch('/dream-add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dream: '', page: '' })
+      }).then(() => location.reload());
+    });
+  });
+
+  // 削除ボタン
+  document.querySelectorAll('.dream-delete-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/dream-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) })
+      }).then(() => location.reload());
+    });
+  });
+
+  // 入力変更
+  document.querySelectorAll('.dream-input, .page-input').forEach((el) => {
+    el.addEventListener('change', () => {
+      const row = el.closest('tr');
+      if (row) sendUpdate(row);
+    });
+  });
+
+  function gatherData(row) {
+    return {
+      id: parseInt(row.dataset.id, 10),
+      dream: row.querySelector('.dream-input').value,
+      page: row.querySelector('.page-input').value
+    };
+  }
+
+  function sendUpdate(row) {
+    const data = gatherData(row);
+    fetch('/dream-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+});

--- a/src/main/resources/templates/dream-box.html
+++ b/src/main/resources/templates/dream-box.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>夢ボックス</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+    </div>
+
+    <div class="database-container">
+      <table class="dream-database">
+        <tr>
+          <th>削除</th>
+          <th>夢</th>
+          <th>ページ</th>
+        </tr>
+        <tr th:each="dream : ${dreamRecords}" th:data-id="${dream.id}">
+          <td><input type="button" value="削除" class="dream-delete-button" /></td>
+          <td><input type="text" th:value="${dream.dream}" class="dream-input" /></td>
+          <td><input type="text" th:value="${dream.page}" class="page-input" /></td>
+        </tr>
+      </table>
+      <button id="new-dream-button">新規夢</button>
+    </div>
+
+    <script th:src="@{/js/dream.js}"></script>
+  </body>
+</html>

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -13,6 +13,7 @@
       <a th:href="@{'/' + ${username} + '/task-top/task-box'}">タスクボックス</a>
       <a th:href="@{'/' + ${username} + '/task-top/awareness-box'}">気づきボックス</a>
       <a th:href="@{'/' + ${username} + '/task-top/word-box'}">単語ボックス</a>
+      <a th:href="@{'/' + ${username} + '/task-top/dream-box'}">夢ボックス</a>
       <a th:href="@{'/' + ${username} + '/task-top/sub-task-box'}">子タスクボックス</a>
     </div>
 
@@ -226,6 +227,20 @@
           </tr>
         </table>
       </div>
+      <div class="database-container">
+        <table class="dream-database">
+          <tr>
+            <th>削除</th>
+            <th>夢</th>
+            <th>ページ</th>
+          </tr>
+          <tr th:each="dream : ${dreamRecords}" th:data-id="${dream.id}">
+            <td><input type="button" value="削除" class="dream-delete-button" /></td>
+            <td><input type="text" th:value="${dream.dream}" class="dream-input" /></td>
+            <td><input type="text" th:value="${dream.page}" class="page-input" /></td>
+          </tr>
+        </table>
+      </div>
     </div>
 
     <!-- idはjs，classはcss用 -->
@@ -242,6 +257,7 @@
     <script th:src="@{/js/task.js}"></script>
     <script th:src="@{/js/awareness.js}"></script>
     <script th:src="@{/js/word.js}"></script>
+    <script th:src="@{/js/dream.js}"></script>
     <script th:src="@{/js/calendar-detail.js}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce DreamRecord entity
- implement DreamRecord repository and service
- add DreamRecord controller
- create Dream box page and JavaScript handlers
- display dream records on task top page and add navigation link

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687397f931a4832a92dcdac3f263ef5e