### PR TITLE
Show completed and uncompleted dreams

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -169,8 +169,15 @@ public class TopController {
             return "redirect:/log-in";
         }
         log.debug("Displaying dream box page");
-        var records = dreamRecordService.getAllRecords();
-        model.addAttribute("dreamRecords", records);
+        var all = dreamRecordService.getAllRecords();
+        var uncompleted = all.stream()
+                .filter(d -> d.getCompletedAt() == null)
+                .toList();
+        var completed = all.stream()
+                .filter(d -> d.getCompletedAt() != null)
+                .toList();
+        model.addAttribute("uncompletedDreamRecords", uncompleted);
+        model.addAttribute("completedDreamRecords", completed);
         model.addAttribute("username", username);
         return "dream-box";
     }

--- a/src/main/java/com/example/demo/entity/DreamRecord.java
+++ b/src/main/java/com/example/demo/entity/DreamRecord.java
@@ -1,9 +1,12 @@
 package com.example.demo.entity;
 
+import java.time.LocalDate;
+
 import lombok.Data;
 
 @Data
 public class DreamRecord {
     private int id; // 自動採番ID
     private String dream; // 夢
+    private LocalDate completedAt; // 完了日
 }

--- a/src/main/java/com/example/demo/repository/dream/DreamRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/dream/DreamRecordRepositoryImpl.java
@@ -20,13 +20,17 @@ public class DreamRecordRepositoryImpl implements DreamRecordRepository {
 
     @Override
     public List<DreamRecord> findAll() {
-        String sql = "SELECT id, dream FROM dream_records ORDER BY id DESC";
+        String sql = "SELECT id, dream, completed_at FROM dream_records ORDER BY id DESC";
         return jdbcTemplate.query(sql, new RowMapper<DreamRecord>() {
             @Override
             public DreamRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
                 DreamRecord r = new DreamRecord();
                 r.setId(rs.getInt("id"));
                 r.setDream(rs.getString("dream"));
+                java.sql.Date comp = rs.getDate("completed_at");
+                if (comp != null) {
+                    r.setCompletedAt(comp.toLocalDate());
+                }
                 return r;
             }
         });
@@ -34,14 +38,16 @@ public class DreamRecordRepositoryImpl implements DreamRecordRepository {
 
     @Override
     public void insertRecord(DreamRecord record) {
-        String sql = "INSERT INTO dream_records (dream) VALUES (?)";
-        jdbcTemplate.update(sql, record.getDream());
+        String sql = "INSERT INTO dream_records (dream, completed_at) VALUES (?, ?)";
+        java.sql.Date comp = record.getCompletedAt() != null ? java.sql.Date.valueOf(record.getCompletedAt()) : null;
+        jdbcTemplate.update(sql, record.getDream(), comp);
     }
 
     @Override
     public void updateRecord(DreamRecord record) {
-        String sql = "UPDATE dream_records SET dream = ? WHERE id = ?";
-        jdbcTemplate.update(sql, record.getDream(), record.getId());
+        String sql = "UPDATE dream_records SET dream = ?, completed_at = ? WHERE id = ?";
+        java.sql.Date comp = record.getCompletedAt() != null ? java.sql.Date.valueOf(record.getCompletedAt()) : null;
+        jdbcTemplate.update(sql, record.getDream(), comp, record.getId());
     }
 
     @Override

--- a/src/main/resources/static/js/dream.js
+++ b/src/main/resources/static/js/dream.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const uncompletedTable = document.getElementById('uncompleted-dream-table');
+  const completedTable = document.getElementById('completed-dream-table');
+
   // 新規夢ボタン
   document.querySelectorAll('#new-dream-button').forEach((btn) => {
     btn.addEventListener('click', () => {
@@ -24,19 +27,53 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  // 入力変更
-  document.querySelectorAll('.dream-input').forEach((el) => {
-    el.addEventListener('change', () => {
-      const row = el.closest('tr');
-      if (row) sendUpdate(row);
+  // 完了・取消ボタン
+  document.querySelectorAll('.dream-complete-button').forEach((btn) => {
+    const row = btn.closest('tr');
+    const comp = row ? row.querySelector('.dream-completed-input') : null;
+    if (comp && comp.value) {
+      btn.value = '取消';
+    }
+    btn.addEventListener('click', () => {
+      if (!row || !comp) return;
+      if (btn.value === '完了') {
+        comp.value = new Date().toISOString().split('T')[0];
+        btn.value = '取消';
+        moveRow(row, true);
+      } else {
+        comp.value = '';
+        btn.value = '完了';
+        moveRow(row, false);
+      }
+      sendUpdate(row);
     });
   });
+
+  // 入力変更
+  document
+    .querySelectorAll('.dream-input, .dream-completed-input')
+    .forEach((el) => {
+      el.addEventListener('change', () => {
+        const row = el.closest('tr');
+        if (row) sendUpdate(row);
+      });
+    });
+
+  function moveRow(row, toCompleted) {
+    if (!row) return;
+    if (toCompleted) {
+      completedTable.tBodies[0].appendChild(row);
+    } else {
+      uncompletedTable.tBodies[0].appendChild(row);
+    }
+  }
 
   function gatherData(row) {
     return {
       id: parseInt(row.dataset.id, 10),
-      dream: row.querySelector('.dream-input').value
-          };
+      dream: row.querySelector('.dream-input').value,
+      completedAt: row.querySelector('.dream-completed-input').value || null,
+    };
   }
 
   function sendUpdate(row) {

--- a/src/main/resources/templates/dream-box.html
+++ b/src/main/resources/templates/dream-box.html
@@ -11,17 +11,40 @@
     </div>
 
     <div class="database-container">
-      <table class="dream-database">
+      <p>未完了夢</p>
+      <table id="uncompleted-dream-table" class="dream-database">
         <tr>
+          <th>完了</th>
           <th>削除</th>
           <th>夢</th>
+          <th>完了日</th>
         </tr>
-        <tr th:each="dream : ${dreamRecords}" th:data-id="${dream.id}">
+        <tr th:each="dream : ${uncompletedDreamRecords}" th:data-id="${dream.id}">
+          <td><input type="button" value="完了" class="dream-complete-button" /></td>
           <td><input type="button" value="削除" class="dream-delete-button" /></td>
           <td><input type="text" th:value="${dream.dream}" class="dream-input" /></td>
+          <td><input type="date" th:value="${dream.completedAt}" class="dream-completed-input" /></td>
         </tr>
       </table>
       <button id="new-dream-button">新規夢</button>
+    </div>
+
+    <div class="database-container">
+      <p>完了済み夢</p>
+      <table id="completed-dream-table" class="dream-database">
+        <tr>
+          <th>完了</th>
+          <th>削除</th>
+          <th>夢</th>
+          <th>完了日</th>
+        </tr>
+        <tr th:each="dream : ${completedDreamRecords}" th:data-id="${dream.id}">
+          <td><input type="button" value="取消" class="dream-complete-button" /></td>
+          <td><input type="button" value="削除" class="dream-delete-button" /></td>
+          <td><input type="text" th:value="${dream.dream}" class="dream-input" /></td>
+          <td><input type="date" th:value="${dream.completedAt}" class="dream-completed-input" /></td>
+        </tr>
+      </table>
     </div>
 
     <script th:src="@{/js/dream.js}"></script>


### PR DESCRIPTION
## Summary
- track completion date for dream records
- split dream box into completed and uncompleted lists
- handle completion in dream JavaScript
- update controller logic
- persist completion date in repository

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent-3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_6873a41c6764832a9348b0f0e921b85c