### PR TITLE
Filter uncompleted dreams on task top

### DIFF
--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -66,6 +66,7 @@ public class TopController {
         model.addAttribute("wordRecords", wordList);
         var dreamList = dreamRecordService.getAllRecords()
                 .stream()
+                .filter(d -> d.getCompletedAt() == null)
                 .limit(5)
                 .toList();
         model.addAttribute("dreamRecords", dreamList);


### PR DESCRIPTION
## Summary
- only show dream records with no completion date on `task-top` by filtering for `completedAt == null`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6873ad47b8dc832a94e70b57ff373021