### PR TITLE
Fix dream completion date on task top

### DIFF
--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -232,18 +232,20 @@
       </div>
       <div class="database-container">
         <table class="dream-database">
-          <tr>
-            <th>報告</th>
-            <th>削除</th>
-            <th>夢</th>
-            <th>詳細</th>
-          </tr>
-          <tr th:each="dream : ${dreamRecords}" th:data-id="${dream.id}">
-            <td><input type="button" value="完了" class="dream-complete-button" /></td>
-            <td><input type="button" value="削除" class="dream-delete-button" /></td>
-            <td><input type="text" th:value="${dream.dream}" class="dream-input" /></td>
-            <td><a th:href="@{'/' + ${username} + '/task-top/dream-page/' + ${dream.id}}">go</a></td>
-          </tr>
+        <tr>
+          <th>報告</th>
+          <th>削除</th>
+          <th>夢</th>
+          <th>詳細</th>
+          <th>完了日</th>
+        </tr>
+        <tr th:each="dream : ${dreamRecords}" th:data-id="${dream.id}">
+          <td><input type="button" value="完了" class="dream-complete-button" /></td>
+          <td><input type="button" value="削除" class="dream-delete-button" /></td>
+          <td><input type="text" th:value="${dream.dream}" class="dream-input" /></td>
+          <td><a th:href="@{'/' + ${username} + '/task-top/dream-page/' + ${dream.id}}">go</a></td>
+          <td><input type="date" th:value="${dream.completedAt}" class="dream-completed-input" /></td>
+        </tr>
         </table>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show completion date column on task-top dream list
- allow dream.js to set completion date

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6873b3a53d70832aa0dedb34229c1e86