### PR TITLE
Hide dream completed date on task top

### DIFF
--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -237,14 +237,14 @@
           <th>削除</th>
           <th>夢</th>
           <th>詳細</th>
-          <th>完了日</th>
+          <th style="display:none;">完了日</th>
         </tr>
         <tr th:each="dream : ${dreamRecords}" th:data-id="${dream.id}">
           <td><input type="button" value="完了" class="dream-complete-button" /></td>
           <td><input type="button" value="削除" class="dream-delete-button" /></td>
           <td><input type="text" th:value="${dream.dream}" class="dream-input" /></td>
           <td><a th:href="@{'/' + ${username} + '/task-top/dream-page/' + ${dream.id}}">go</a></td>
-          <td><input type="date" th:value="${dream.completedAt}" class="dream-completed-input" /></td>
+          <td style="display:none;"><input type="hidden" th:value="${dream.completedAt}" class="dream-completed-input" /></td>
         </tr>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- keep dream completion date value but hide the column on task top page

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6873b86b13bc832abb45084a5bebc03e