### PR TITLE
Fix null table bug in dream.js

### DIFF
--- a/src/main/resources/static/js/dream.js
+++ b/src/main/resources/static/js/dream.js
@@ -62,8 +62,10 @@ document.addEventListener('DOMContentLoaded', () => {
   function moveRow(row, toCompleted) {
     if (!row) return;
     if (toCompleted) {
-      completedTable.tBodies[0].appendChild(row);
-    } else {
+      if (completedTable && completedTable.tBodies.length > 0) {
+        completedTable.tBodies[0].appendChild(row);
+      }
+    } else if (uncompletedTable && uncompletedTable.tBodies.length > 0) {
       uncompletedTable.tBodies[0].appendChild(row);
     }
   }


### PR DESCRIPTION
## Summary
- guard table access when moving dream rows

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6873babfb1c4832abb1d5030a148402c