### PR TITLE
Implement Dream Page feature

### DIFF
--- a/src/main/java/com/example/demo/controller/DreamPageController.java
+++ b/src/main/java/com/example/demo/controller/DreamPageController.java
@@ -1,0 +1,54 @@
+package com.example.demo.controller;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.DreamPage;
+import com.example.demo.entity.DreamRecord;
+import com.example.demo.service.page.DreamPageService;
+import com.example.demo.service.dream.DreamRecordService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class DreamPageController {
+
+    private final DreamPageService service;
+    private final DreamRecordService recordService;
+
+    @GetMapping("/{username}/task-top/dream-page/{dreamId}")
+    public String showDreamPage(@PathVariable String username, @PathVariable int dreamId,
+            Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying dream page for dream {}", dreamId);
+        DreamPage page = service.getOrCreatePage(dreamId);
+        DreamRecord dream = recordService.getAllRecords().stream()
+                .filter(r -> r.getId() == dreamId)
+                .findFirst()
+                .orElse(null);
+        model.addAttribute("page", page);
+        model.addAttribute("dream", dream);
+        model.addAttribute("username", username);
+        return "dream-page";
+    }
+
+    @PostMapping("/dream-page-update")
+    public ResponseEntity<Void> updateDreamPage(@RequestBody DreamPage page) {
+        log.debug("Updating dream page id {}", page.getId());
+        service.updatePage(page);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/entity/DreamPage.java
+++ b/src/main/java/com/example/demo/entity/DreamPage.java
@@ -1,0 +1,10 @@
+package com.example.demo.entity;
+
+import lombok.Data;
+
+@Data
+public class DreamPage {
+    private int id; // 自動採番ID
+    private int dreamId; // 対応する夢レコードID
+    private String content; // ページ内容
+}

--- a/src/main/java/com/example/demo/repository/page/DreamPageRepository.java
+++ b/src/main/java/com/example/demo/repository/page/DreamPageRepository.java
@@ -1,0 +1,10 @@
+package com.example.demo.repository.page;
+
+import com.example.demo.entity.DreamPage;
+
+public interface DreamPageRepository {
+    DreamPage findByDreamId(int dreamId);
+    void insertPage(DreamPage page);
+    void updatePage(DreamPage page);
+    void deleteByDreamId(int dreamId);
+}

--- a/src/main/java/com/example/demo/repository/page/DreamPageRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/page/DreamPageRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.example.demo.repository.page;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.DreamPage;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DreamPageRepositoryImpl implements DreamPageRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public DreamPage findByDreamId(int dreamId) {
+        String sql = "SELECT id, dream_id, content FROM dream_pages WHERE dream_id = ?";
+        List<DreamPage> list = jdbcTemplate.query(sql, new RowMapper<DreamPage>() {
+            @Override
+            public DreamPage mapRow(ResultSet rs, int rowNum) throws SQLException {
+                DreamPage p = new DreamPage();
+                p.setId(rs.getInt("id"));
+                p.setDreamId(rs.getInt("dream_id"));
+                p.setContent(rs.getString("content"));
+                return p;
+            }
+        }, dreamId);
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    @Override
+    public void insertPage(DreamPage page) {
+        String sql = "INSERT INTO dream_pages (dream_id, content) VALUES (?, ?)";
+        jdbcTemplate.update(sql, page.getDreamId(), page.getContent());
+    }
+
+    @Override
+    public void updatePage(DreamPage page) {
+        String sql = "UPDATE dream_pages SET content = ? WHERE id = ?";
+        jdbcTemplate.update(sql, page.getContent(), page.getId());
+    }
+
+    @Override
+    public void deleteByDreamId(int dreamId) {
+        String sql = "DELETE FROM dream_pages WHERE dream_id = ?";
+        jdbcTemplate.update(sql, dreamId);
+    }
+}

--- a/src/main/java/com/example/demo/service/dream/DreamRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/dream/DreamRecordServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.example.demo.entity.DreamRecord;
 import com.example.demo.repository.dream.DreamRecordRepository;
+import com.example.demo.service.page.DreamPageService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 public class DreamRecordServiceImpl implements DreamRecordService {
 
     private final DreamRecordRepository repository;
+    private final DreamPageService pageService;
 
     @Override
     public List<DreamRecord> getAllRecords() {
@@ -38,6 +40,7 @@ public class DreamRecordServiceImpl implements DreamRecordService {
     @Override
     public void deleteById(int id) {
         log.debug("Deleting dream record id {}", id);
+        pageService.deleteByDreamId(id);
         repository.deleteById(id);
     }
 }

--- a/src/main/java/com/example/demo/service/page/DreamPageService.java
+++ b/src/main/java/com/example/demo/service/page/DreamPageService.java
@@ -1,0 +1,9 @@
+package com.example.demo.service.page;
+
+import com.example.demo.entity.DreamPage;
+
+public interface DreamPageService {
+    DreamPage getOrCreatePage(int dreamId);
+    void updatePage(DreamPage page);
+    void deleteByDreamId(int dreamId);
+}

--- a/src/main/java/com/example/demo/service/page/DreamPageServiceImpl.java
+++ b/src/main/java/com/example/demo/service/page/DreamPageServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.demo.service.page;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.DreamPage;
+import com.example.demo.repository.page.DreamPageRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DreamPageServiceImpl implements DreamPageService {
+
+    private final DreamPageRepository repository;
+
+    @Override
+    public DreamPage getOrCreatePage(int dreamId) {
+        log.debug("Fetching dream page for dream {}", dreamId);
+        DreamPage p = repository.findByDreamId(dreamId);
+        if (p == null) {
+            p = new DreamPage();
+            p.setDreamId(dreamId);
+            p.setContent("");
+            repository.insertPage(p);
+            p = repository.findByDreamId(dreamId);
+        }
+        return p;
+    }
+
+    @Override
+    public void updatePage(DreamPage page) {
+        log.debug("Updating dream page id {}", page.getId());
+        repository.updatePage(page);
+    }
+
+    @Override
+    public void deleteByDreamId(int dreamId) {
+        log.debug("Deleting dream page for dream {}", dreamId);
+        repository.deleteByDreamId(dreamId);
+    }
+}

--- a/src/main/resources/static/js/dream-page.js
+++ b/src/main/resources/static/js/dream-page.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const textarea = document.getElementById('dream-page-content');
+  if (!textarea) return;
+  const save = () => {
+    fetch('/dream-page-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: pageId, content: textarea.value })
+    });
+  };
+  textarea.addEventListener('change', save);
+});

--- a/src/main/resources/templates/dream-page.html
+++ b/src/main/resources/templates/dream-page.html
@@ -18,5 +18,10 @@
     <div class="page-container">
       <textarea id="dream-page-content" rows="20" cols="80" th:text="${page.content}"></textarea>
     </div>
+
+    <script th:src="@{/js/dream-page.js}"></script>
+    <script th:inline="javascript">
+      const pageId = [[${page.id}]];
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add DreamPage entity and repository layer
- implement DreamPageService and controller
- update DreamRecordServiceImpl to clean up DreamPage when deleting a record
- create dream-page.js for saving page content
- include new script in dream-page.html

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6873c3661858832a93e3cea8e431f611