### PR TITLE
Display current time on task top page

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -88,6 +88,14 @@ body.task-body {
   font-weight: bold;
 }
 
+/* display current time on task-top */
+#current-time {
+  position: fixed;
+  top: 10px;
+  left: 200px;
+  font-weight: bold;
+}
+
 #new-challenge-button {
   position: fixed;
   top: 510px;

--- a/src/main/resources/static/js/current-time.js
+++ b/src/main/resources/static/js/current-time.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.getElementById('current-time');
+  if (!el) return;
+  const update = () => {
+    const now = new Date();
+    const h = String(now.getHours()).padStart(2, '0');
+    const m = String(now.getMinutes()).padStart(2, '0');
+    const s = String(now.getSeconds()).padStart(2, '0');
+    el.textContent = `${h}時${m}分${s}秒`;
+  };
+  update();
+  setInterval(update, 1000);
+});

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -19,6 +19,8 @@
 
     </div>
 
+    <div id="current-time"></div>
+
     <!-- idの方でjs，classの方でcssの処理を適用-->
     <div id="calendar" class="calendar-area"></div>
 
@@ -266,5 +268,6 @@
     <script th:src="@{/js/word.js}"></script>
     <script th:src="@{/js/dream.js}"></script>
     <script th:src="@{/js/calendar-detail.js}"></script>
+    <script th:src="@{/js/current-time.js}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- show current time on the task top page
- style new time display element
- add small script to refresh the displayed time every second

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6873c7be6564832aadb9843377f822c7