### PR TITLE
Add frequency property for routines

### DIFF
--- a/src/main/java/com/example/demo/entity/Routine.java
+++ b/src/main/java/com/example/demo/entity/Routine.java
@@ -7,4 +7,5 @@ public class Routine {
     private int id;       // ID
     private String name;  // ルーティン名
     private String type;  // 区分（予定・タスク・挑戦）
+    private String frequency; // 頻度（毎日・毎週・毎月）
 }

--- a/src/main/java/com/example/demo/repository/routine/RoutineRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/routine/RoutineRepositoryImpl.java
@@ -25,26 +25,27 @@ public class RoutineRepositoryImpl implements RoutineRepository {
             r.setId(rs.getInt("id"));
             r.setName(rs.getString("name"));
             r.setType(rs.getString("type"));
+            r.setFrequency(rs.getString("frequency"));
             return r;
         }
     };
 
     @Override
     public List<Routine> findAll() {
-        String sql = "SELECT id, name, type FROM routines ORDER BY id";
+        String sql = "SELECT id, name, type, frequency FROM routines ORDER BY id";
         return jdbcTemplate.query(sql, ROW_MAPPER);
     }
 
     @Override
     public void insertRoutine(Routine routine) {
-        String sql = "INSERT INTO routines (name, type) VALUES (?, ?)";
-        jdbcTemplate.update(sql, routine.getName(), routine.getType());
+        String sql = "INSERT INTO routines (name, type, frequency) VALUES (?, ?, ?)";
+        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency());
     }
 
     @Override
     public void updateRoutine(Routine routine) {
-        String sql = "UPDATE routines SET name = ?, type = ? WHERE id = ?";
-        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getId());
+        String sql = "UPDATE routines SET name = ?, type = ?, frequency = ? WHERE id = ?";
+        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency(), routine.getId());
     }
 
     @Override

--- a/src/main/resources/static/js/routine.js
+++ b/src/main/resources/static/js/routine.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch('/routine-add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: '', type: '予定' }),
+        body: JSON.stringify({ name: '', type: '予定', frequency: '毎日' }),
       }).then(() => location.reload());
     });
   });
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // 入力変更
   document
-    .querySelectorAll('.routine-name-input, .routine-type-select')
+    .querySelectorAll('.routine-name-input, .routine-type-select, .routine-frequency-select')
     .forEach((el) => {
       el.addEventListener('change', () => {
         const row = el.closest('tr');
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
       id: parseInt(row.dataset.id, 10),
       name: row.querySelector('.routine-name-input').value,
       type: row.querySelector('.routine-type-select').value,
+      frequency: row.querySelector('.routine-frequency-select').value,
     };
   }
 

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -259,6 +259,7 @@
             <th>削除</th>
             <th>ルーティン名</th>
             <th>区分</th>
+            <th>頻度</th>
           </tr>
           <tr th:each="routine : ${routines}" th:data-id="${routine.id}">
             <td><input type="button" value="削除" class="routine-delete-button" /></td>
@@ -268,6 +269,13 @@
                 <option value="予定" th:selected="${routine.type == '予定'}">予定</option>
                 <option value="タスク" th:selected="${routine.type == 'タスク'}">タスク</option>
                 <option value="挑戦" th:selected="${routine.type == '挑戦'}">挑戦</option>
+              </select>
+            </td>
+            <td>
+              <select class="routine-frequency-select">
+                <option value="毎日" th:selected="${routine.frequency == '毎日'}">毎日</option>
+                <option value="毎週" th:selected="${routine.frequency == '毎週'}">毎週</option>
+                <option value="毎月" th:selected="${routine.frequency == '毎月'}">毎月</option>
               </select>
             </td>
           </tr>


### PR DESCRIPTION
## Summary
- support frequency for routines so users can pick Daily/Weekly/Monthly

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6873da3ed8f4832aaf701f2a074e4b11