### PR TITLE
Add timing to routines

### DIFF
--- a/src/main/java/com/example/demo/entity/Routine.java
+++ b/src/main/java/com/example/demo/entity/Routine.java
@@ -1,5 +1,7 @@
 package com.example.demo.entity;
 
+import java.time.LocalTime;
+
 import lombok.Data;
 
 @Data
@@ -8,4 +10,5 @@ public class Routine {
     private String name;  // ルーティン名
     private String type;  // 区分（予定・タスク・挑戦）
     private String frequency; // 頻度（毎日・毎週・毎月）
+    private LocalTime timing; // タイミング
 }

--- a/src/main/java/com/example/demo/repository/routine/RoutineRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/routine/RoutineRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.example.demo.repository.routine;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -26,26 +27,32 @@ public class RoutineRepositoryImpl implements RoutineRepository {
             r.setName(rs.getString("name"));
             r.setType(rs.getString("type"));
             r.setFrequency(rs.getString("frequency"));
+            java.sql.Time tm = rs.getTime("timing");
+            if (tm != null) {
+                r.setTiming(tm.toLocalTime());
+            }
             return r;
         }
     };
 
     @Override
     public List<Routine> findAll() {
-        String sql = "SELECT id, name, type, frequency FROM routines ORDER BY id";
+        String sql = "SELECT id, name, type, frequency, timing FROM routines ORDER BY id";
         return jdbcTemplate.query(sql, ROW_MAPPER);
     }
 
     @Override
     public void insertRoutine(Routine routine) {
-        String sql = "INSERT INTO routines (name, type, frequency) VALUES (?, ?, ?)";
-        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency());
+        String sql = "INSERT INTO routines (name, type, frequency, timing) VALUES (?, ?, ?, ?)";
+        java.sql.Time tm = routine.getTiming() != null ? java.sql.Time.valueOf(routine.getTiming()) : null;
+        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency(), tm);
     }
 
     @Override
     public void updateRoutine(Routine routine) {
-        String sql = "UPDATE routines SET name = ?, type = ?, frequency = ? WHERE id = ?";
-        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency(), routine.getId());
+        String sql = "UPDATE routines SET name = ?, type = ?, frequency = ?, timing = ? WHERE id = ?";
+        java.sql.Time tm = routine.getTiming() != null ? java.sql.Time.valueOf(routine.getTiming()) : null;
+        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency(), tm, routine.getId());
     }
 
     @Override

--- a/src/main/resources/static/js/routine.js
+++ b/src/main/resources/static/js/routine.js
@@ -1,11 +1,30 @@
 document.addEventListener('DOMContentLoaded', () => {
+  function initTimeSelects(hourSel, minuteSel, time) {
+    for (let h = 0; h < 24; h++) {
+      const opt = document.createElement('option');
+      opt.value = String(h).padStart(2, '0');
+      opt.textContent = opt.value;
+      hourSel.appendChild(opt);
+    }
+    for (let m = 0; m < 60; m += 5) {
+      const opt = document.createElement('option');
+      opt.value = String(m).padStart(2, '0');
+      opt.textContent = opt.value;
+      minuteSel.appendChild(opt);
+    }
+    if (time) {
+      const [h, mi] = time.split(':');
+      hourSel.value = h;
+      minuteSel.value = mi.padStart(2, '0');
+    }
+  }
   // 新規ルーティンボタン
   document.querySelectorAll('#new-routine-button').forEach((btn) => {
     btn.addEventListener('click', () => {
       fetch('/routine-add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: '', type: '予定', frequency: '毎日' }),
+        body: JSON.stringify({ name: '', type: '予定', frequency: '毎日', timing: '12:00' }),
       }).then(() => location.reload());
     });
   });
@@ -24,9 +43,24 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  document.querySelectorAll('.routine-hour').forEach((sel) => {
+    const minuteSel = sel.parentElement.querySelector('.routine-minute');
+    initTimeSelects(sel, minuteSel, sel.dataset.time);
+    sel.addEventListener('change', () => {
+      const row = sel.closest('tr');
+      if (row) sendUpdate(row);
+    });
+    if (minuteSel) {
+      minuteSel.addEventListener('change', () => {
+        const row = sel.closest('tr');
+        if (row) sendUpdate(row);
+      });
+    }
+  });
+
   // 入力変更
   document
-    .querySelectorAll('.routine-name-input, .routine-type-select, .routine-frequency-select')
+    .querySelectorAll('.routine-name-input, .routine-type-select, .routine-frequency-select, .routine-hour, .routine-minute')
     .forEach((el) => {
       el.addEventListener('change', () => {
         const row = el.closest('tr');
@@ -40,6 +74,10 @@ document.addEventListener('DOMContentLoaded', () => {
       name: row.querySelector('.routine-name-input').value,
       type: row.querySelector('.routine-type-select').value,
       frequency: row.querySelector('.routine-frequency-select').value,
+      timing:
+        row.querySelector('.routine-hour').value.padStart(2, '0') +
+        ':' +
+        row.querySelector('.routine-minute').value.padStart(2, '0'),
     };
   }
 

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -260,6 +260,7 @@
             <th>ルーティン名</th>
             <th>区分</th>
             <th>頻度</th>
+            <th>タイミング</th>
           </tr>
           <tr th:each="routine : ${routines}" th:data-id="${routine.id}">
             <td><input type="button" value="削除" class="routine-delete-button" /></td>
@@ -277,6 +278,11 @@
                 <option value="毎週" th:selected="${routine.frequency == '毎週'}">毎週</option>
                 <option value="毎月" th:selected="${routine.frequency == '毎月'}">毎月</option>
               </select>
+            </td>
+            <td>
+              <select class="routine-hour" th:data-time="${routine.timing}"></select>
+              :
+              <select class="routine-minute"></select>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
## Summary
- add `timing` field to `Routine`
- persist timing in `RoutineRepositoryImpl`
- show timing selectors in `task-top.html`
- handle timing in `routine.js`

## Testing
- `mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6873dde8222c832a80f74c6e1d1588bc