### PR TITLE
Implement scheduled routine to schedule sync

### DIFF
--- a/src/main/java/com/example/demo/TaskAlpha.java
+++ b/src/main/java/com/example/demo/TaskAlpha.java
@@ -2,8 +2,10 @@ package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TaskAlpha {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/demo/service/routine/RoutineScheduler.java
+++ b/src/main/java/com/example/demo/service/routine/RoutineScheduler.java
@@ -1,0 +1,64 @@
+package com.example.demo.service.routine;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.example.demo.entity.Routine;
+import com.example.demo.entity.Schedule;
+import com.example.demo.service.schedule.ScheduleService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RoutineScheduler {
+
+    private final RoutineService routineService;
+    private final ScheduleService scheduleService;
+
+    @Scheduled(cron = "0 * * * * *")
+    public void addDailySchedules() {
+        LocalTime now = LocalTime.now().truncatedTo(ChronoUnit.MINUTES);
+        LocalDate today = LocalDate.now();
+        List<Routine> routines = routineService.getAllRoutines();
+        for (Routine r : routines) {
+            if ("予定".equals(r.getType()) && "毎日".equals(r.getFrequency()) && r.getTiming() != null) {
+                LocalTime timing = r.getTiming().truncatedTo(ChronoUnit.MINUTES);
+                if (now.equals(timing)) {
+                    boolean exists = scheduleService.getAllSchedules().stream()
+                            .anyMatch(s -> s.getTitle().equals(r.getName()) && today.equals(s.getScheduleDate()));
+                    if (!exists) {
+                        Schedule s = new Schedule();
+                        s.setAddFlag(true);
+                        s.setTitle(r.getName());
+                        s.setDayOfWeek(getJapaneseDayOfWeek(today.getDayOfWeek()));
+                        s.setScheduleDate(today);
+                        s.setStartTime(r.getTiming());
+                        s.setEndTime(r.getTiming().plusHours(1));
+                        s.setLocation("");
+                        s.setDetail("");
+                        s.setFeedback("");
+                        s.setPoint(1);
+                        s.setCompletedDay(null);
+                        scheduleService.addSchedule(s);
+                        log.debug("Added schedule for routine {}", r.getName());
+                    }
+                }
+            }
+        }
+    }
+
+    private String getJapaneseDayOfWeek(DayOfWeek day) {
+        return day.getDisplayName(TextStyle.SHORT, Locale.JAPANESE);
+    }
+}


### PR DESCRIPTION
## Summary
- enable scheduled tasks in the Spring Boot application
- create `RoutineScheduler` that adds a schedule when a daily routine time matches

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6873e67723c0832a9881b3cdff3d8ba0