### PR TITLE
Add start date field to Routine

### DIFF
--- a/src/main/java/com/example/demo/entity/Routine.java
+++ b/src/main/java/com/example/demo/entity/Routine.java
@@ -1,6 +1,7 @@
 package com.example.demo.entity;
 
 import java.time.LocalTime;
+import java.time.LocalDate;
 
 import lombok.Data;
 
@@ -10,5 +11,6 @@ public class Routine {
     private String name;  // ルーティン名
     private String type;  // 区分（予定・タスク・挑戦）
     private String frequency; // 頻度（毎日・毎週・毎月）
+    private LocalDate startDate; // 開始日
     private LocalTime timing; // タイミング
 }

--- a/src/main/java/com/example/demo/repository/routine/RoutineRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/routine/RoutineRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.example.demo.repository.routine;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -27,6 +28,10 @@ public class RoutineRepositoryImpl implements RoutineRepository {
             r.setName(rs.getString("name"));
             r.setType(rs.getString("type"));
             r.setFrequency(rs.getString("frequency"));
+            java.sql.Date sd = rs.getDate("start_date");
+            if (sd != null) {
+                r.setStartDate(sd.toLocalDate());
+            }
             java.sql.Time tm = rs.getTime("timing");
             if (tm != null) {
                 r.setTiming(tm.toLocalTime());
@@ -37,22 +42,24 @@ public class RoutineRepositoryImpl implements RoutineRepository {
 
     @Override
     public List<Routine> findAll() {
-        String sql = "SELECT id, name, type, frequency, timing FROM routines ORDER BY id";
+        String sql = "SELECT id, name, type, frequency, start_date, timing FROM routines ORDER BY id";
         return jdbcTemplate.query(sql, ROW_MAPPER);
     }
 
     @Override
     public void insertRoutine(Routine routine) {
-        String sql = "INSERT INTO routines (name, type, frequency, timing) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO routines (name, type, frequency, start_date, timing) VALUES (?, ?, ?, ?, ?)";
+        java.sql.Date sd = routine.getStartDate() != null ? java.sql.Date.valueOf(routine.getStartDate()) : null;
         java.sql.Time tm = routine.getTiming() != null ? java.sql.Time.valueOf(routine.getTiming()) : null;
-        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency(), tm);
+        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency(), sd, tm);
     }
 
     @Override
     public void updateRoutine(Routine routine) {
-        String sql = "UPDATE routines SET name = ?, type = ?, frequency = ?, timing = ? WHERE id = ?";
+        String sql = "UPDATE routines SET name = ?, type = ?, frequency = ?, start_date = ?, timing = ? WHERE id = ?";
+        java.sql.Date sd = routine.getStartDate() != null ? java.sql.Date.valueOf(routine.getStartDate()) : null;
         java.sql.Time tm = routine.getTiming() != null ? java.sql.Time.valueOf(routine.getTiming()) : null;
-        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency(), tm, routine.getId());
+        jdbcTemplate.update(sql, routine.getName(), routine.getType(), routine.getFrequency(), sd, tm, routine.getId());
     }
 
     @Override

--- a/src/main/resources/static/js/routine.js
+++ b/src/main/resources/static/js/routine.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch('/routine-add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: '', type: '予定', frequency: '毎日', timing: '12:00' }),
+        body: JSON.stringify({ name: '', type: '予定', frequency: '毎日', startDate: null, timing: '12:00' }),
       }).then(() => location.reload());
     });
   });
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // 入力変更
   document
-    .querySelectorAll('.routine-name-input, .routine-type-select, .routine-frequency-select, .routine-hour, .routine-minute')
+    .querySelectorAll('.routine-name-input, .routine-type-select, .routine-frequency-select, .routine-start-input, .routine-hour, .routine-minute')
     .forEach((el) => {
       el.addEventListener('change', () => {
         const row = el.closest('tr');
@@ -74,6 +74,7 @@ document.addEventListener('DOMContentLoaded', () => {
       name: row.querySelector('.routine-name-input').value,
       type: row.querySelector('.routine-type-select').value,
       frequency: row.querySelector('.routine-frequency-select').value,
+      startDate: row.querySelector('.routine-start-input').value || null,
       timing:
         row.querySelector('.routine-hour').value.padStart(2, '0') +
         ':' +

--- a/src/main/resources/templates/task-top.html
+++ b/src/main/resources/templates/task-top.html
@@ -261,6 +261,7 @@
             <th>詳細</th>
             <th>区分</th>
             <th>頻度</th>
+            <th>開始日</th>
             <th>タイミング</th>
           </tr>
           <tr th:each="routine : ${routines}" th:data-id="${routine.id}">
@@ -280,6 +281,9 @@
                 <option value="毎週" th:selected="${routine.frequency == '毎週'}">毎週</option>
                 <option value="毎月" th:selected="${routine.frequency == '毎月'}">毎月</option>
               </select>
+            </td>
+            <td>
+              <input type="date" th:value="${routine.startDate}" class="routine-start-input" />
             </td>
             <td>
               <select class="routine-hour" th:data-time="${routine.timing}"></select>


### PR DESCRIPTION
## Summary
- add `startDate` field to `Routine`
- persist the new field in `RoutineRepositoryImpl`
- support editing start date in the routine table UI
- update JS to send the field

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6873f008cac0832a8efbcf11ab6bd71b