### PR TITLE
Ensure daily routine tasks are added every day

### DIFF
--- a/src/main/java/com/example/demo/repository/task/TaskRepository.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepository.java
@@ -11,4 +11,13 @@ public interface TaskRepository {
     void updateTask(Task task);
     void deleteById(int id);
     int sumCompletedLevels();
+
+    /**
+     * 指定したタイトルで、作成日が指定日に該当するタスクが存在するかを判定する。
+     *
+     * @param title タイトル
+     * @param date  作成日
+     * @return 存在する場合は true
+     */
+    boolean existsByTitleAndDate(String title, java.time.LocalDate date);
 }

--- a/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/task/TaskRepositoryImpl.java
@@ -130,4 +130,11 @@ public class TaskRepositoryImpl implements TaskRepository {
         Integer result = jdbcTemplate.queryForObject(sql, Integer.class);
         return result != null ? result : 0;
     }
+
+    @Override
+    public boolean existsByTitleAndDate(String title, java.time.LocalDate date) {
+        String sql = "SELECT COUNT(*) FROM tasks WHERE title = ? AND DATE(created_at) = ?";
+        Integer count = jdbcTemplate.queryForObject(sql, Integer.class, title, java.sql.Date.valueOf(date));
+        return count != null && count > 0;
+    }
 }

--- a/src/main/java/com/example/demo/service/routine/RoutineScheduler.java
+++ b/src/main/java/com/example/demo/service/routine/RoutineScheduler.java
@@ -143,10 +143,7 @@ public class RoutineScheduler {
             if ("タスク".equals(r.getType()) && "毎日".equals(r.getFrequency()) && r.getTiming() != null) {
                 LocalTime timing = r.getTiming().truncatedTo(ChronoUnit.MINUTES);
                 if (now.equals(timing)) {
-                    boolean exists = taskService.getAllTasks().stream()
-                            .anyMatch(t -> t.getTitle().equals(r.getName()) &&
-                                    t.getCreatedAt() != null &&
-                                    today.equals(t.getCreatedAt().toLocalDate()));
+                    boolean exists = taskService.existsTaskCreatedOn(r.getName(), today);
                     if (!exists) {
                         Task t = new Task();
                         t.setTitle(r.getName());
@@ -173,10 +170,7 @@ public class RoutineScheduler {
                 LocalDate start = r.getStartDate();
                 long days = ChronoUnit.DAYS.between(start, today);
                 if (days >= 0 && days % 7 == 0 && now.equals(timing)) {
-                    boolean exists = taskService.getAllTasks().stream()
-                            .anyMatch(t -> t.getTitle().equals(r.getName()) &&
-                                    t.getCreatedAt() != null &&
-                                    today.equals(t.getCreatedAt().toLocalDate()));
+                    boolean exists = taskService.existsTaskCreatedOn(r.getName(), today);
                     if (!exists) {
                         Task t = new Task();
                         t.setTitle(r.getName());
@@ -203,10 +197,7 @@ public class RoutineScheduler {
                 LocalDate start = r.getStartDate();
                 long months = ChronoUnit.MONTHS.between(start.withDayOfMonth(1), today.withDayOfMonth(1));
                 if (months >= 0 && today.getDayOfMonth() == start.getDayOfMonth() && now.equals(timing)) {
-                    boolean exists = taskService.getAllTasks().stream()
-                            .anyMatch(t -> t.getTitle().equals(r.getName()) &&
-                                    t.getCreatedAt() != null &&
-                                    today.equals(t.getCreatedAt().toLocalDate()));
+                    boolean exists = taskService.existsTaskCreatedOn(r.getName(), today);
                     if (!exists) {
                         Task t = new Task();
                         t.setTitle(r.getName());

--- a/src/main/java/com/example/demo/service/task/TaskService.java
+++ b/src/main/java/com/example/demo/service/task/TaskService.java
@@ -16,4 +16,13 @@ public interface TaskService {
     int getTotalCompletedLevels();
 
     Task getTaskById(int id);
+
+    /**
+     * 指定タイトルで作成日が指定日に該当するタスクが存在するか判定する。
+     *
+     * @param title タイトル
+     * @param date  作成日
+     * @return 存在する場合は true
+     */
+    boolean existsTaskCreatedOn(String title, java.time.LocalDate date);
 }

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -156,6 +156,11 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
+    public boolean existsTaskCreatedOn(String title, LocalDate date) {
+        return repository.existsByTitleAndDate(title, date);
+    }
+
+    @Override
     public Task getTaskById(int id) {
         log.debug("Fetching task by id {}", id);
         Task t = repository.findById(id);


### PR DESCRIPTION
## Summary
- add repository method to check if a task exists by title and date
- expose new method via TaskService
- update RoutineScheduler to use this check when adding routine tasks

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687a51fe0d18832a85173892e29dc19e