### PR TITLE
Implement start date check for daily routine tasks

### DIFF
--- a/src/main/java/com/example/demo/service/routine/RoutineScheduler.java
+++ b/src/main/java/com/example/demo/service/routine/RoutineScheduler.java
@@ -142,7 +142,8 @@ public class RoutineScheduler {
         for (Routine r : routines) {
             if ("タスク".equals(r.getType()) && "毎日".equals(r.getFrequency()) && r.getTiming() != null) {
                 LocalTime timing = r.getTiming().truncatedTo(ChronoUnit.MINUTES);
-                if (now.equals(timing)) {
+                LocalDate start = r.getStartDate();
+                if ((start == null || !today.isBefore(start)) && now.equals(timing)) {
                     boolean exists = taskService.existsTaskCreatedOn(r.getName(), today);
                     if (!exists) {
                         Task t = new Task();


### PR DESCRIPTION
## Summary
- ensure `RoutineScheduler` only triggers daily tasks on or after the specified start date

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687a58fe48d8832aad7a87430e6cf929