### PR TITLE
Allow editing awareness entry from page

### DIFF
--- a/src/main/resources/static/js/awareness-page.js
+++ b/src/main/resources/static/js/awareness-page.js
@@ -1,14 +1,32 @@
 document.addEventListener('DOMContentLoaded', () => {
   const textarea = document.getElementById('awareness-page-content');
-  textarea.addEventListener('change', save);//テクストエリアに記入が完了したら
+  const awarenessInput = document.getElementById('awareness-input');
 
-  if (!textarea) return;
-  //AwarenessPageControllerにPOST
-  const save = () => {
+  if (textarea) {
+    textarea.addEventListener('change', savePage);
+  }
+
+  if (awarenessInput) {
+    awarenessInput.addEventListener('change', saveRecord);
+  }
+
+  function savePage() {
     fetch('/awareness-page-update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: pageId, content: textarea.value })
     });
-  };
+  }
+
+  function saveRecord() {
+    fetch('/awareness-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: recordId,
+        awareness: awarenessInput.value,
+        awarenessLevel: awarenessLevel
+      })
+    });
+  }
 });

--- a/src/main/resources/templates/awareness-page.html
+++ b/src/main/resources/templates/awareness-page.html
@@ -11,18 +11,21 @@
       <a th:href="@{'/' + ${username} + '/task-top/awareness-box'}">一覧へ戻る</a>
     </div>
 
-    <div class="awareness-title">
-      <span th:text="${record != null ? record.awareness : ''}"></span>
-    </div>
+  <div class="awareness-title">
+      <input type="text" id="awareness-input"
+             th:value="${record != null ? record.awareness : ''}" />
+  </div>
 
     <div class="page-container">
       <textarea id="awareness-page-content" rows="20" cols="80" th:text="${page.content}"></textarea>
     </div>
 
     <script th:src="@{/js/awareness-page.js}"></script>
-    <!-- awareness-page.jsで pageIdを使うために-->
+    <!-- awareness-page.jsで pageIdやrecordIdを使うために-->
     <script th:inline="javascript">
       const pageId = [[${page.id}]];
+      const recordId = [[${record.id}]];
+      const awarenessLevel = [[${record.awarenessLevel}]];
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- enable editing of `AwarenessRecord.awareness` directly from the awareness page
- expose record information to the awareness page's JavaScript
- update JS to send record updates and fix initialization order

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687a62caea2c832a9bf8eb22366a6d27