### PR TITLE
Improve awareness page layout

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -383,3 +383,22 @@ td {
   border-radius: 4px;
   box-sizing: border-box;
 }
+/* style for awareness page */
+#awareness-input {
+  width: 100%;
+  font-size: 32px;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+#awareness-page-content {
+  width: 100%;
+  height: 400px;
+  font-family: monospace, monospace;
+  font-size: 16px;
+  padding: 10px;
+  resize: vertical;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}

--- a/src/main/resources/static/js/awareness-page.js
+++ b/src/main/resources/static/js/awareness-page.js
@@ -3,11 +3,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const awarenessInput = document.getElementById('awareness-input');
 
   if (textarea) {
+    autoResize();
+    textarea.addEventListener('input', autoResize);
     textarea.addEventListener('change', savePage);
   }
 
   if (awarenessInput) {
     awarenessInput.addEventListener('change', saveRecord);
+  }
+
+  function autoResize() {
+    textarea.style.height = 'auto';
+    textarea.style.height = textarea.scrollHeight + 'px';
   }
 
   function savePage() {

--- a/src/main/resources/templates/awareness-page.html
+++ b/src/main/resources/templates/awareness-page.html
@@ -17,7 +17,7 @@
   </div>
 
     <div class="page-container">
-      <textarea id="awareness-page-content" rows="20" cols="80" th:text="${page.content}"></textarea>
+      <textarea id="awareness-page-content" th:text="${page.content}"></textarea>
     </div>
 
     <script th:src="@{/js/awareness-page.js}"></script>


### PR DESCRIPTION
## Summary
- enlarge awareness input area and make the text area fill the page
- auto-resize the awareness page textarea as user types

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687a650363b4832a9cb5a0ecb25ea076