### PR TITLE
Cascade delete tasks with child subtasks

### DIFF
--- a/src/main/java/com/example/demo/repository/subtask/SubTaskRepository.java
+++ b/src/main/java/com/example/demo/repository/subtask/SubTaskRepository.java
@@ -14,6 +14,12 @@ public interface SubTaskRepository {
     void insertSubTask(SubTask subTask);
     void updateSubTask(SubTask subTask);
     void deleteById(int id);
+    /**
+     * 指定した親タスクに紐づく子タスクをすべて削除する。
+     *
+     * @param taskId 親タスクのID
+     */
+    void deleteByTaskId(int taskId);
     int countByTaskId(int taskId);
     int countCompletedByTaskId(int taskId);
 

--- a/src/main/java/com/example/demo/repository/subtask/SubTaskRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/subtask/SubTaskRepositoryImpl.java
@@ -72,6 +72,12 @@ public class SubTaskRepositoryImpl implements SubTaskRepository {
     }
 
     @Override
+    public void deleteByTaskId(int taskId) {
+        String sql = "DELETE FROM sub_tasks WHERE task_id = ?";
+        jdbcTemplate.update(sql, taskId);
+    }
+
+    @Override
     public int countByTaskId(int taskId) {
         String sql = "SELECT COUNT(*) FROM sub_tasks WHERE task_id = ?";
         Integer result = jdbcTemplate.queryForObject(sql, Integer.class, taskId);

--- a/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
+++ b/src/main/java/com/example/demo/service/task/TaskServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import com.example.demo.entity.Task;
 import com.example.demo.repository.task.TaskRepository;
 import com.example.demo.repository.subtask.SubTaskRepository;
+import com.example.demo.repository.page.TaskPageRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ public class TaskServiceImpl implements TaskService {
 
     private final TaskRepository repository;
     private final SubTaskRepository subTaskRepository;
+    private final TaskPageRepository taskPageRepository;
 
     /**
      * カテゴリから締切日時を計算する。
@@ -146,6 +148,9 @@ public class TaskServiceImpl implements TaskService {
     @Override
     public void deleteTaskById(int id) {
         log.debug("Deleting task with id {}", id);
+        // 子タスクとページを先に削除してから親タスクを削除する
+        taskPageRepository.deleteByTaskId(id);
+        subTaskRepository.deleteByTaskId(id);
         repository.deleteById(id);
     }
 


### PR DESCRIPTION
## Summary
- add `deleteByTaskId` to `SubTaskRepository`
- implement deletion for all subtasks belonging to a task
- inject `TaskPageRepository` in `TaskServiceImpl`
- remove subtasks and task pages before deleting a task

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687bc0fe3470832a90a5d0b59695e8fd