### PR TITLE
Add awareness record trash with 10‑minute restore

### DIFF
--- a/src/main/java/com/example/demo/controller/AwarenessRecordController.java
+++ b/src/main/java/com/example/demo/controller/AwarenessRecordController.java
@@ -38,4 +38,11 @@ public class AwarenessRecordController {
         service.deleteById(record.getId());
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/awareness-restore")
+    public ResponseEntity<Void> restoreRecord(@RequestBody AwarenessRecord record) {
+        log.debug("Restoring awareness record id {}", record.getId());
+        service.restoreById(record.getId());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/demo/controller/AwarenessTrashController.java
+++ b/src/main/java/com/example/demo/controller/AwarenessTrashController.java
@@ -1,0 +1,33 @@
+package com.example.demo.controller;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.example.demo.service.awareness.AwarenessTrashService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class AwarenessTrashController {
+
+    private final AwarenessTrashService trashService;
+
+    @GetMapping("/{username}/task-top/awareness-trash")
+    public String showTrash(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying awareness trash page");
+        model.addAttribute("deletedRecords", trashService.getDeletedRecords());
+        model.addAttribute("username", username);
+        return "awareness-trash";
+    }
+}

--- a/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepository.java
+++ b/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepository.java
@@ -7,7 +7,11 @@ import com.example.demo.entity.AwarenessRecord;
 public interface AwarenessRecordRepository {
     List<AwarenessRecord> findAll();
 
+    AwarenessRecord findById(int id);
+
     void insertRecord(AwarenessRecord record);
+
+    void insertRecordWithId(AwarenessRecord record);
 
     void updateRecord(AwarenessRecord record);
 

--- a/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/awareness/AwarenessRecordRepositoryImpl.java
@@ -34,9 +34,33 @@ public class AwarenessRecordRepositoryImpl implements AwarenessRecordRepository 
     }
 
     @Override
+    public AwarenessRecord findById(int id) {
+        String sql = "SELECT id, awareness, awareness_level FROM awareness_records WHERE id = ?";
+        return jdbcTemplate.queryForObject(sql, new RowMapper<AwarenessRecord>() {
+            @Override
+            public AwarenessRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
+                AwarenessRecord r = new AwarenessRecord();
+                r.setId(rs.getInt("id"));
+                r.setAwareness(rs.getString("awareness"));
+                r.setAwarenessLevel(rs.getInt("awareness_level"));
+                return r;
+            }
+        }, id);
+    }
+
+    @Override
     public void insertRecord(AwarenessRecord record) {
         String sql = "INSERT INTO awareness_records (awareness, awareness_level) VALUES (?, ?)";
         jdbcTemplate.update(sql,
+                record.getAwareness(),
+                record.getAwarenessLevel());
+    }
+
+    @Override
+    public void insertRecordWithId(AwarenessRecord record) {
+        String sql = "INSERT INTO awareness_records (id, awareness, awareness_level) VALUES (?, ?, ?)";
+        jdbcTemplate.update(sql,
+                record.getId(),
                 record.getAwareness(),
                 record.getAwarenessLevel());
     }

--- a/src/main/java/com/example/demo/repository/page/AwarenessPageRepository.java
+++ b/src/main/java/com/example/demo/repository/page/AwarenessPageRepository.java
@@ -7,6 +7,8 @@ public interface AwarenessPageRepository {
 
     void insertPage(AwarenessPage page);
 
+    void insertPageWithId(AwarenessPage page);
+
     void updatePage(AwarenessPage page);
 
     void deleteByRecordId(int recordId);

--- a/src/main/java/com/example/demo/repository/page/AwarenessPageRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/page/AwarenessPageRepositoryImpl.java
@@ -41,6 +41,12 @@ public class AwarenessPageRepositoryImpl implements AwarenessPageRepository {
     }
 
     @Override
+    public void insertPageWithId(AwarenessPage page) {
+        String sql = "INSERT INTO awareness_pages (id, record_id, content) VALUES (?, ?, ?)";
+        jdbcTemplate.update(sql, page.getId(), page.getRecordId(), page.getContent());
+    }
+
+    @Override
     public void updatePage(AwarenessPage page) {
         String sql = "UPDATE awareness_pages SET content = ? WHERE id = ?";
         jdbcTemplate.update(sql, page.getContent(), page.getId());

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordService.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordService.java
@@ -13,5 +13,9 @@ public interface AwarenessRecordService {
 
     void deleteById(int id);
 
+    void restoreById(int id);
+
+    AwarenessRecord getRecordById(int id);
+
     int getTotalAwarenessLevel();
 }

--- a/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessRecordServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.example.demo.entity.AwarenessRecord;
 import com.example.demo.repository.awareness.AwarenessRecordRepository;
 import com.example.demo.service.page.AwarenessPageService;
+import com.example.demo.service.awareness.AwarenessTrashService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ public class AwarenessRecordServiceImpl implements AwarenessRecordService {
 
     private final AwarenessRecordRepository repository;
     private final AwarenessPageService pageService;
+    private final AwarenessTrashService trashService;
 
     @Override
     public List<AwarenessRecord> getAllRecords() {
@@ -40,8 +42,27 @@ public class AwarenessRecordServiceImpl implements AwarenessRecordService {
     @Override
     public void deleteById(int id) {
         log.debug("Deleting awareness record id {}", id);
+        AwarenessRecord record = repository.findById(id);
+        var page = pageService.getPage(id);
+        if (page != null) {
+            trashService.addDeletedRecord(record, page);
+        } else {
+            trashService.addDeletedRecord(record, null);
+        }
         pageService.deleteByRecordId(id);
         repository.deleteById(id);
+    }
+
+    @Override
+    public void restoreById(int id) {
+        log.debug("Restoring awareness record id {}", id);
+        trashService.restore(id);
+    }
+
+    @Override
+    public AwarenessRecord getRecordById(int id) {
+        log.debug("Fetching awareness record id {}", id);
+        return repository.findById(id);
     }
 
     @Override

--- a/src/main/java/com/example/demo/service/awareness/AwarenessTrashService.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessTrashService.java
@@ -1,0 +1,14 @@
+package com.example.demo.service.awareness;
+
+import java.util.List;
+
+import com.example.demo.entity.AwarenessPage;
+import com.example.demo.entity.AwarenessRecord;
+
+public interface AwarenessTrashService {
+    void addDeletedRecord(AwarenessRecord record, AwarenessPage page);
+
+    List<AwarenessRecord> getDeletedRecords();
+
+    void restore(int recordId);
+}

--- a/src/main/java/com/example/demo/service/awareness/AwarenessTrashServiceImpl.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessTrashServiceImpl.java
@@ -1,0 +1,73 @@
+package com.example.demo.service.awareness;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.AwarenessPage;
+import com.example.demo.entity.AwarenessRecord;
+import com.example.demo.repository.awareness.AwarenessRecordRepository;
+import com.example.demo.repository.page.AwarenessPageRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AwarenessTrashServiceImpl implements AwarenessTrashService {
+
+    private final AwarenessRecordRepository recordRepository;
+    private final AwarenessPageRepository pageRepository;
+
+    private static class TrashItem {
+        AwarenessRecord record;
+        AwarenessPage page;
+        LocalDateTime deletedAt;
+    }
+
+    private final Map<Integer, TrashItem> trash = new ConcurrentHashMap<>();
+
+    @Override
+    public void addDeletedRecord(AwarenessRecord record, AwarenessPage page) {
+        TrashItem item = new TrashItem();
+        item.record = record;
+        item.page = page;
+        item.deletedAt = LocalDateTime.now();
+        trash.put(record.getId(), item);
+    }
+
+    @Override
+    public List<AwarenessRecord> getDeletedRecords() {
+        removeExpired();
+        List<AwarenessRecord> list = new ArrayList<>();
+        for (TrashItem item : trash.values()) {
+            list.add(item.record);
+        }
+        return list;
+    }
+
+    @Override
+    public void restore(int recordId) {
+        TrashItem item = trash.remove(recordId);
+        if (item != null) {
+            log.debug("Restoring awareness record id {}", recordId);
+            if (item.page != null) {
+                pageRepository.insertPageWithId(item.page);
+            }
+            recordRepository.insertRecordWithId(item.record);
+        }
+    }
+
+    @Scheduled(fixedRate = 60000)
+    public void removeExpired() {
+        LocalDateTime now = LocalDateTime.now();
+        trash.entrySet().removeIf(e -> Duration.between(e.getValue().deletedAt, now).toMinutes() >= 10);
+    }
+}

--- a/src/main/java/com/example/demo/service/page/AwarenessPageService.java
+++ b/src/main/java/com/example/demo/service/page/AwarenessPageService.java
@@ -4,6 +4,8 @@ import com.example.demo.entity.AwarenessPage;
 
 public interface AwarenessPageService {
     AwarenessPage getOrCreatePage(int recordId);
+    AwarenessPage getPage(int recordId);
     void updatePage(AwarenessPage page);
+    void insertPageWithId(AwarenessPage page);
     void deleteByRecordId(int recordId);
 }

--- a/src/main/java/com/example/demo/service/page/AwarenessPageServiceImpl.java
+++ b/src/main/java/com/example/demo/service/page/AwarenessPageServiceImpl.java
@@ -30,9 +30,21 @@ public class AwarenessPageServiceImpl implements AwarenessPageService {
     }
 
     @Override
+    public AwarenessPage getPage(int recordId) {
+        log.debug("Fetching page only for record {}", recordId);
+        return repository.findByRecordId(recordId);
+    }
+
+    @Override
     public void updatePage(AwarenessPage page) {
         log.debug("Updating page id {}", page.getId());
         repository.updatePage(page);
+    }
+
+    @Override
+    public void insertPageWithId(AwarenessPage page) {
+        log.debug("Inserting page with id {}", page.getId());
+        repository.insertPageWithId(page);
     }
 
     @Override

--- a/src/main/resources/static/js/awareness-trash.js
+++ b/src/main/resources/static/js/awareness-trash.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.awareness-restore-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/awareness-restore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) })
+      }).then(() => location.reload());
+    });
+  });
+});

--- a/src/main/resources/templates/awareness-box.html
+++ b/src/main/resources/templates/awareness-box.html
@@ -8,6 +8,7 @@
   <body class="task-body">
     <div class="link-area">
       <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+      <a th:href="@{'/' + ${username} + '/task-top/awareness-trash'}">削除済み</a>
     </div>
 
     <div class="database-container">

--- a/src/main/resources/templates/awareness-trash.html
+++ b/src/main/resources/templates/awareness-trash.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>削除済み気づき</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top/awareness-box'}">一覧へ戻る</a>
+    </div>
+
+    <div class="database-container">
+      <table class="awareness-database">
+        <tr>
+          <th>復元</th>
+          <th>気づき</th>
+          <th>気づき度</th>
+        </tr>
+        <tr th:each="record : ${deletedRecords}" th:data-id="${record.id}">
+          <td><input type="button" value="復元" class="awareness-restore-button" /></td>
+          <td th:text="${record.awareness}"></td>
+          <td th:text="${record.awarenessLevel}"></td>
+        </tr>
+      </table>
+    </div>
+
+    <script th:src="@{/js/awareness-trash.js}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- support restoring deleted awareness records for 10 minutes
- add AwarenessTrashService to keep deleted records temporarily
- update AwarenessRecordService to use trash and provide restore API
- create awareness-trash page and JavaScript for restoring
- expose new endpoints for restore

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687bc44a26a8832ab7ed8331bfe1b3e3