### PR TITLE
Disable ANSI color codes in logs

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Enable debug level logging for application classes
 logging.level.com.example.demo=DEBUG
+# Disable ANSI color codes in log output
+spring.output.ansi.enabled=NEVER
 


### PR DESCRIPTION
## Summary
- update application properties to disable ANSI log color sequences

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_687bc8e64594832aaadd018a535db4bb