### PR TITLE
Fix restore order for awareness records

### DIFF
--- a/src/main/java/com/example/demo/service/awareness/AwarenessTrashServiceImpl.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessTrashServiceImpl.java
@@ -58,10 +58,11 @@ public class AwarenessTrashServiceImpl implements AwarenessTrashService {
         TrashItem item = trash.remove(recordId);
         if (item != null) {
             log.debug("Restoring awareness record id {}", recordId);
+            // Insert the record first so that the page can reference it
+            recordRepository.insertRecordWithId(item.record);
             if (item.page != null) {
                 pageRepository.insertPageWithId(item.page);
             }
-            recordRepository.insertRecordWithId(item.record);
         }
     }
 


### PR DESCRIPTION
## Summary
- fix order of inserts when restoring awareness records so record is added before its page

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687bce1c814c832aa9f45649d16e0c77