### PR TITLE
Add timer for awareness record deletion

### DIFF
--- a/src/main/java/com/example/demo/dto/DeletedAwarenessRecordInfo.java
+++ b/src/main/java/com/example/demo/dto/DeletedAwarenessRecordInfo.java
@@ -1,0 +1,10 @@
+package com.example.demo.dto;
+
+import com.example.demo.entity.AwarenessRecord;
+import lombok.Data;
+
+@Data
+public class DeletedAwarenessRecordInfo {
+    private AwarenessRecord record;
+    private long expiryEpochMillis;
+}

--- a/src/main/java/com/example/demo/service/awareness/AwarenessTrashService.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessTrashService.java
@@ -4,11 +4,12 @@ import java.util.List;
 
 import com.example.demo.entity.AwarenessPage;
 import com.example.demo.entity.AwarenessRecord;
+import com.example.demo.dto.DeletedAwarenessRecordInfo;
 
 public interface AwarenessTrashService {
     void addDeletedRecord(AwarenessRecord record, AwarenessPage page);
 
-    List<AwarenessRecord> getDeletedRecords();
+    List<DeletedAwarenessRecordInfo> getDeletedRecords();
 
     void restore(int recordId);
 }

--- a/src/main/java/com/example/demo/service/awareness/AwarenessTrashServiceImpl.java
+++ b/src/main/java/com/example/demo/service/awareness/AwarenessTrashServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.time.ZoneId;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import com.example.demo.entity.AwarenessPage;
 import com.example.demo.entity.AwarenessRecord;
 import com.example.demo.repository.awareness.AwarenessRecordRepository;
 import com.example.demo.repository.page.AwarenessPageRepository;
+import com.example.demo.dto.DeletedAwarenessRecordInfo;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,11 +46,17 @@ public class AwarenessTrashServiceImpl implements AwarenessTrashService {
     }
 
     @Override
-    public List<AwarenessRecord> getDeletedRecords() {
+    public List<DeletedAwarenessRecordInfo> getDeletedRecords() {
         removeExpired();
-        List<AwarenessRecord> list = new ArrayList<>();
+        List<DeletedAwarenessRecordInfo> list = new ArrayList<>();
+        LocalDateTime now = LocalDateTime.now();
         for (TrashItem item : trash.values()) {
-            list.add(item.record);
+            DeletedAwarenessRecordInfo info = new DeletedAwarenessRecordInfo();
+            info.setRecord(item.record);
+            long expiry = item.deletedAt.plusMinutes(10)
+                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            info.setExpiryEpochMillis(expiry);
+            list.add(info);
         }
         return list;
     }

--- a/src/main/resources/static/js/awareness-trash.js
+++ b/src/main/resources/static/js/awareness-trash.js
@@ -11,4 +11,21 @@ document.addEventListener('DOMContentLoaded', () => {
       }).then(() => location.reload());
     });
   });
+
+  document.querySelectorAll('tr[data-expiry]').forEach((row) => {
+    const cell = row.querySelector('.time-left');
+    const expiry = parseInt(row.dataset.expiry, 10);
+    const update = () => {
+      const diff = expiry - Date.now();
+      if (diff <= 0) {
+        cell.textContent = '0:00';
+        return;
+      }
+      const minutes = Math.floor(diff / 60000);
+      const seconds = Math.floor((diff % 60000) / 1000);
+      cell.textContent = `${minutes}:${String(seconds).padStart(2, '0')}`;
+    };
+    update();
+    setInterval(update, 1000);
+  });
 });

--- a/src/main/resources/templates/awareness-trash.html
+++ b/src/main/resources/templates/awareness-trash.html
@@ -16,11 +16,13 @@
           <th>復元</th>
           <th>気づき</th>
           <th>気づき度</th>
+          <th>残り時間</th>
         </tr>
-        <tr th:each="record : ${deletedRecords}" th:data-id="${record.id}">
+        <tr th:each="item : ${deletedRecords}" th:data-id="${item.record.id}" th:data-expiry="${item.expiryEpochMillis}">
           <td><input type="button" value="復元" class="awareness-restore-button" /></td>
-          <td th:text="${record.awareness}"></td>
-          <td th:text="${record.awarenessLevel}"></td>
+          <td th:text="${item.record.awareness}"></td>
+          <td th:text="${item.record.awarenessLevel}"></td>
+          <td class="time-left"></td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- show countdown until a deleted awareness record is purged
- compute expiration time in the trash service
- expose new DTO `DeletedAwarenessRecordInfo`
- update template and JavaScript to render a live timer

## Testing
- `mvn -q -e test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687bd1570348832ab37d7d7818c5a155