### PR TITLE
Add diary box feature

### DIFF
--- a/src/main/java/com/example/demo/controller/DiaryRecordController.java
+++ b/src/main/java/com/example/demo/controller/DiaryRecordController.java
@@ -1,0 +1,41 @@
+package com.example.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.example.demo.entity.DiaryRecord;
+import com.example.demo.service.diary.DiaryRecordService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class DiaryRecordController {
+
+    private final DiaryRecordService service;
+
+    @PostMapping("/diary-add")
+    public ResponseEntity<Void> addRecord(@RequestBody DiaryRecord record) {
+        log.debug("Adding diary record");
+        service.addRecord(record);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/diary-update")
+    public ResponseEntity<Void> updateRecord(@RequestBody DiaryRecord record) {
+        log.debug("Updating diary record id {}", record.getId());
+        service.updateRecord(record);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/diary-delete")
+    public ResponseEntity<Void> deleteRecord(@RequestBody DiaryRecord record) {
+        log.debug("Deleting diary record id {}", record.getId());
+        service.deleteById(record.getId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/demo/controller/TopController.java
+++ b/src/main/java/com/example/demo/controller/TopController.java
@@ -15,6 +15,7 @@ import com.example.demo.service.task.TaskService;
 import com.example.demo.service.subtask.SubTaskService;
 import com.example.demo.service.word.WordRecordService;
 import com.example.demo.service.dream.DreamRecordService;
+import com.example.demo.service.diary.DiaryRecordService;
 import com.example.demo.service.routine.RoutineService;
 
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class TopController {
     private final AwarenessRecordService awarenessRecordService;
     private final WordRecordService wordRecordService;
     private final DreamRecordService dreamRecordService;
+    private final DiaryRecordService diaryRecordService;
     private final RoutineService routineService;
 
     @GetMapping("/{username}/task-top")
@@ -72,6 +74,11 @@ public class TopController {
                 .limit(5)
                 .toList();
         model.addAttribute("dreamRecords", dreamList);
+        var diaryList = diaryRecordService.getAllRecords()
+                .stream()
+                .limit(5)
+                .toList();
+        model.addAttribute("diaryRecords", diaryList);
         var routineList = routineService.getAllRoutines();
         model.addAttribute("routines", routineList);
         model.addAttribute("username", username);
@@ -186,6 +193,19 @@ public class TopController {
         model.addAttribute("completedDreamRecords", completed);
         model.addAttribute("username", username);
         return "dream-box";
+    }
+
+    @GetMapping("/{username}/task-top/diary-box")
+    public String showDiaryBox(@PathVariable String username, Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying diary box page");
+        var records = diaryRecordService.getAllRecords();
+        model.addAttribute("diaryRecords", records);
+        model.addAttribute("username", username);
+        return "diary-box";
     }
 
     @GetMapping("/{username}/task-top/sub-task-box")

--- a/src/main/java/com/example/demo/entity/DiaryRecord.java
+++ b/src/main/java/com/example/demo/entity/DiaryRecord.java
@@ -1,0 +1,12 @@
+package com.example.demo.entity;
+
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class DiaryRecord {
+    private int id;               // ID
+    private LocalDate recordDate; // 記入日
+    private String content;       // 日記内容
+}

--- a/src/main/java/com/example/demo/repository/diary/DiaryRecordRepository.java
+++ b/src/main/java/com/example/demo/repository/diary/DiaryRecordRepository.java
@@ -1,0 +1,11 @@
+package com.example.demo.repository.diary;
+
+import java.util.List;
+import com.example.demo.entity.DiaryRecord;
+
+public interface DiaryRecordRepository {
+    List<DiaryRecord> findAll();
+    void insertRecord(DiaryRecord record);
+    void updateRecord(DiaryRecord record);
+    void deleteById(int id);
+}

--- a/src/main/java/com/example/demo/repository/diary/DiaryRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/diary/DiaryRecordRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.example.demo.repository.diary;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.entity.DiaryRecord;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DiaryRecordRepositoryImpl implements DiaryRecordRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<DiaryRecord> findAll() {
+        String sql = "SELECT id, record_date, content FROM diary_records ORDER BY id DESC";
+        return jdbcTemplate.query(sql, new RowMapper<DiaryRecord>() {
+            @Override
+            public DiaryRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
+                DiaryRecord d = new DiaryRecord();
+                d.setId(rs.getInt("id"));
+                d.setRecordDate(rs.getDate("record_date").toLocalDate());
+                d.setContent(rs.getString("content"));
+                return d;
+            }
+        });
+    }
+
+    @Override
+    public void insertRecord(DiaryRecord record) {
+        String sql = "INSERT INTO diary_records (record_date, content) VALUES (?, ?)";
+        LocalDate date = record.getRecordDate();
+        java.sql.Date sqlDate = date != null ? java.sql.Date.valueOf(date) : null;
+        jdbcTemplate.update(sql, sqlDate, record.getContent());
+    }
+
+    @Override
+    public void updateRecord(DiaryRecord record) {
+        String sql = "UPDATE diary_records SET record_date = ?, content = ? WHERE id = ?";
+        java.sql.Date sqlDate = record.getRecordDate() != null ? java.sql.Date.valueOf(record.getRecordDate()) : null;
+        jdbcTemplate.update(sql, sqlDate, record.getContent(), record.getId());
+    }
+
+    @Override
+    public void deleteById(int id) {
+        String sql = "DELETE FROM diary_records WHERE id = ?";
+        jdbcTemplate.update(sql, id);
+    }
+}

--- a/src/main/java/com/example/demo/service/diary/DiaryRecordService.java
+++ b/src/main/java/com/example/demo/service/diary/DiaryRecordService.java
@@ -1,0 +1,11 @@
+package com.example.demo.service.diary;
+
+import java.util.List;
+import com.example.demo.entity.DiaryRecord;
+
+public interface DiaryRecordService {
+    List<DiaryRecord> getAllRecords();
+    void addRecord(DiaryRecord record);
+    void updateRecord(DiaryRecord record);
+    void deleteById(int id);
+}

--- a/src/main/java/com/example/demo/service/diary/DiaryRecordServiceImpl.java
+++ b/src/main/java/com/example/demo/service/diary/DiaryRecordServiceImpl.java
@@ -1,0 +1,43 @@
+package com.example.demo.service.diary;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.entity.DiaryRecord;
+import com.example.demo.repository.diary.DiaryRecordRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DiaryRecordServiceImpl implements DiaryRecordService {
+
+    private final DiaryRecordRepository repository;
+
+    @Override
+    public List<DiaryRecord> getAllRecords() {
+        log.debug("Fetching all diary records");
+        return repository.findAll();
+    }
+
+    @Override
+    public void addRecord(DiaryRecord record) {
+        log.debug("Adding diary record");
+        repository.insertRecord(record);
+    }
+
+    @Override
+    public void updateRecord(DiaryRecord record) {
+        log.debug("Updating diary record id {}", record.getId());
+        repository.updateRecord(record);
+    }
+
+    @Override
+    public void deleteById(int id) {
+        log.debug("Deleting diary record id {}", id);
+        repository.deleteById(id);
+    }
+}

--- a/src/main/resources/static/js/diary.js
+++ b/src/main/resources/static/js/diary.js
@@ -1,0 +1,53 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // 新規日記ボタン
+  document.querySelectorAll('#new-diary-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      fetch('/diary-add', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recordDate: new Date().toISOString().split('T')[0], content: '' })
+      }).then(() => location.reload());
+    });
+  });
+
+  // 削除ボタン
+  document.querySelectorAll('.diary-delete-button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row = btn.closest('tr');
+      if (!row) return;
+      const id = row.dataset.id;
+      fetch('/diary-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: parseInt(id, 10) })
+      }).then(() => location.reload());
+    });
+  });
+
+  // 入力変更
+  document
+    .querySelectorAll('.diary-date-input, .diary-content-input')
+    .forEach((el) => {
+      el.addEventListener('change', () => {
+        const row = el.closest('tr');
+        if (row) sendUpdate(row);
+      });
+    });
+
+  function gatherData(row) {
+    return {
+      id: parseInt(row.dataset.id, 10),
+      recordDate: row.querySelector('.diary-date-input').value,
+      content: row.querySelector('.diary-content-input').value
+    };
+  }
+
+  function sendUpdate(row) {
+    const data = gatherData(row);
+    fetch('/diary-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+  }
+});

--- a/src/main/resources/templates/diary-box.html
+++ b/src/main/resources/templates/diary-box.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>日記ボックス</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+    </div>
+
+    <div class="database-container">
+      <table class="diary-database">
+        <tr>
+          <th>削除</th>
+          <th>日付</th>
+          <th>内容</th>
+        </tr>
+        <tr th:each="diary : ${diaryRecords}" th:data-id="${diary.id}">
+          <td><input type="button" value="削除" class="diary-delete-button" /></td>
+          <td><input type="date" th:value="${diary.recordDate}" class="diary-date-input" /></td>
+          <td><input type="text" th:value="${diary.content}" class="diary-content-input" /></td>
+        </tr>
+      </table>
+      <button id="new-diary-button">新規日記</button>
+    </div>
+
+    <script th:src="@{/js/diary.js}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement diary record backend (entity, repository, service, controller)
- add diary box page and JavaScript for CRUD operations
- integrate diary list into top page

## Testing
- `mvn -q -DskipTests=false test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688620c2700c832aa298dbfad65f6698