### PR TITLE
Add daily diary auto creation

### DIFF
--- a/src/main/java/com/example/demo/service/diary/DiaryRecordScheduler.java
+++ b/src/main/java/com/example/demo/service/diary/DiaryRecordScheduler.java
@@ -1,0 +1,28 @@
+package com.example.demo.service.diary;
+
+import java.time.LocalDate;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.example.demo.entity.DiaryRecord;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DiaryRecordScheduler {
+
+    private final DiaryRecordService service;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void addDailyRecord() {
+        DiaryRecord record = new DiaryRecord();
+        record.setRecordDate(LocalDate.now());
+        record.setContent("");
+        service.addRecord(record);
+        log.debug("Added daily diary record for {}", record.getRecordDate());
+    }
+}


### PR DESCRIPTION
## Summary
- add scheduler to insert an empty diary entry at midnight

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688624e2f180832a924324a64c1b5e8d