### PR TITLE
Add diary detail field and detail page

### DIFF
--- a/src/main/java/com/example/demo/controller/DiaryPageController.java
+++ b/src/main/java/com/example/demo/controller/DiaryPageController.java
@@ -1,0 +1,39 @@
+package com.example.demo.controller;
+
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.example.demo.entity.DiaryRecord;
+import com.example.demo.service.diary.DiaryRecordService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class DiaryPageController {
+
+    private final DiaryRecordService recordService;
+
+    @GetMapping("/{username}/task-top/diary-page/{recordId}")
+    public String showDiaryPage(@PathVariable String username, @PathVariable int recordId,
+            Model model, HttpSession session) {
+        String loginUser = (String) session.getAttribute("loginUser");
+        if (loginUser == null || !loginUser.equals(username)) {
+            return "redirect:/log-in";
+        }
+        log.debug("Displaying diary page for record {}", recordId);
+        DiaryRecord record = recordService.getAllRecords().stream()
+                .filter(r -> r.getId() == recordId)
+                .findFirst()
+                .orElse(null);
+        model.addAttribute("record", record);
+        model.addAttribute("username", username);
+        return "diary-page";
+    }
+}

--- a/src/main/java/com/example/demo/entity/DiaryRecord.java
+++ b/src/main/java/com/example/demo/entity/DiaryRecord.java
@@ -8,5 +8,6 @@ import lombok.Data;
 public class DiaryRecord {
     private int id;               // ID
     private LocalDate recordDate; // 記入日
-    private String content;       // 日記内容
+    private String content;       // タイトル
+    private String detail;        // 詳細
 }

--- a/src/main/java/com/example/demo/repository/diary/DiaryRecordRepositoryImpl.java
+++ b/src/main/java/com/example/demo/repository/diary/DiaryRecordRepositoryImpl.java
@@ -21,7 +21,7 @@ public class DiaryRecordRepositoryImpl implements DiaryRecordRepository {
 
     @Override
     public List<DiaryRecord> findAll() {
-        String sql = "SELECT id, record_date, content FROM diary_records ORDER BY id DESC";
+        String sql = "SELECT id, record_date, content, detail FROM diary_records ORDER BY id DESC";
         return jdbcTemplate.query(sql, new RowMapper<DiaryRecord>() {
             @Override
             public DiaryRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
@@ -29,6 +29,7 @@ public class DiaryRecordRepositoryImpl implements DiaryRecordRepository {
                 d.setId(rs.getInt("id"));
                 d.setRecordDate(rs.getDate("record_date").toLocalDate());
                 d.setContent(rs.getString("content"));
+                d.setDetail(rs.getString("detail"));
                 return d;
             }
         });
@@ -36,17 +37,17 @@ public class DiaryRecordRepositoryImpl implements DiaryRecordRepository {
 
     @Override
     public void insertRecord(DiaryRecord record) {
-        String sql = "INSERT INTO diary_records (record_date, content) VALUES (?, ?)";
+        String sql = "INSERT INTO diary_records (record_date, content, detail) VALUES (?, ?, ?)";
         LocalDate date = record.getRecordDate();
         java.sql.Date sqlDate = date != null ? java.sql.Date.valueOf(date) : null;
-        jdbcTemplate.update(sql, sqlDate, record.getContent());
+        jdbcTemplate.update(sql, sqlDate, record.getContent(), record.getDetail());
     }
 
     @Override
     public void updateRecord(DiaryRecord record) {
-        String sql = "UPDATE diary_records SET record_date = ?, content = ? WHERE id = ?";
+        String sql = "UPDATE diary_records SET record_date = ?, content = ?, detail = ? WHERE id = ?";
         java.sql.Date sqlDate = record.getRecordDate() != null ? java.sql.Date.valueOf(record.getRecordDate()) : null;
-        jdbcTemplate.update(sql, sqlDate, record.getContent(), record.getId());
+        jdbcTemplate.update(sql, sqlDate, record.getContent(), record.getDetail(), record.getId());
     }
 
     @Override

--- a/src/main/java/com/example/demo/service/diary/DiaryRecordScheduler.java
+++ b/src/main/java/com/example/demo/service/diary/DiaryRecordScheduler.java
@@ -22,6 +22,7 @@ public class DiaryRecordScheduler {
         DiaryRecord record = new DiaryRecord();
         record.setRecordDate(LocalDate.now());
         record.setContent("");
+        record.setDetail("");
         service.addRecord(record);
         log.debug("Added daily diary record for {}", record.getRecordDate());
     }

--- a/src/main/resources/static/js/diary-page.js
+++ b/src/main/resources/static/js/diary-page.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const textarea = document.getElementById('diary-detail-content');
+  const titleInput = document.getElementById('diary-title-input');
+
+  if (textarea) {
+    autoResize();
+    textarea.addEventListener('input', autoResize);
+    textarea.addEventListener('change', save);
+  }
+
+  if (titleInput) {
+    enableFullTextDisplay();
+    titleInput.addEventListener('change', save);
+  }
+
+  function autoResize() {
+    textarea.style.height = 'auto';
+    textarea.style.height = textarea.scrollHeight + 'px';
+  }
+
+  function save() {
+    fetch('/diary-update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: recordId,
+        recordDate: recordDate,
+        content: titleInput.value,
+        detail: textarea.value
+      })
+    });
+  }
+
+  function enableFullTextDisplay() {
+    let originalWidth = '';
+    const adjustWidth = () => {
+      titleInput.style.width = 'auto';
+      const w = titleInput.scrollWidth + 4;
+      titleInput.style.width = w + 'px';
+    };
+    adjustWidth();
+    titleInput.addEventListener('focus', () => {
+      originalWidth = titleInput.style.width || titleInput.offsetWidth + 'px';
+      adjustWidth();
+    });
+    titleInput.addEventListener('input', adjustWidth);
+    titleInput.addEventListener('blur', () => {
+      titleInput.style.width = originalWidth;
+    });
+  }
+});

--- a/src/main/resources/static/js/diary.js
+++ b/src/main/resources/static/js/diary.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch('/diary-add', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ recordDate: new Date().toISOString().split('T')[0], content: '' })
+        body: JSON.stringify({ recordDate: new Date().toISOString().split('T')[0], content: '', detail: '' })
       }).then(() => location.reload());
     });
   });
@@ -38,7 +38,8 @@ document.addEventListener('DOMContentLoaded', () => {
     return {
       id: parseInt(row.dataset.id, 10),
       recordDate: row.querySelector('.diary-date-input').value,
-      content: row.querySelector('.diary-content-input').value
+      content: row.querySelector('.diary-content-input').value,
+      detail: row.dataset.detail
     };
   }
 

--- a/src/main/resources/templates/diary-box.html
+++ b/src/main/resources/templates/diary-box.html
@@ -14,11 +14,13 @@
       <table class="diary-database">
         <tr>
           <th>削除</th>
+          <th>詳細</th>
           <th>日付</th>
           <th>内容</th>
         </tr>
-        <tr th:each="diary : ${diaryRecords}" th:data-id="${diary.id}">
+        <tr th:each="diary : ${diaryRecords}" th:data-id="${diary.id}" th:data-detail="${diary.detail}">
           <td><input type="button" value="削除" class="diary-delete-button" /></td>
+          <td><a th:href="@{'/' + ${username} + '/task-top/diary-page/' + ${diary.id}}">go</a></td>
           <td><input type="date" th:value="${diary.recordDate}" class="diary-date-input" /></td>
           <td><input type="text" th:value="${diary.content}" class="diary-content-input" /></td>
         </tr>

--- a/src/main/resources/templates/diary-page.html
+++ b/src/main/resources/templates/diary-page.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>日記ページ</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+  </head>
+  <body class="task-body">
+    <div class="link-area">
+      <a th:href="@{'/' + ${username} + '/task-top'}">TOPへ</a>
+      <a th:href="@{'/' + ${username} + '/task-top/diary-box'}">一覧へ戻る</a>
+    </div>
+
+    <div class="diary-title">
+      <input type="text" id="diary-title-input"
+             th:value="${record != null ? record.content : ''}" />
+    </div>
+
+    <div class="page-container">
+      <textarea id="diary-detail-content" th:text="${record.detail}"></textarea>
+    </div>
+
+    <script th:src="@{/js/diary-page.js}"></script>
+    <script th:inline="javascript">
+      const recordId = [[${record.id}]];
+      const recordDate = '[[${record.recordDate}]]';
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `detail` property for diary records and persist it
- provide `go` links to open diary detail pages
- include controller, template, and scripts for editing diary details

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_689aa43992c8832ab3f922bd13838293