### PR TITLE
Add title field to diary detail page

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -356,7 +356,8 @@ td {
 }
 
 /* task-page.htmlのスタイル---------------------------------------------------------------------------- */
-.awareness-title {
+.awareness-title,
+.diary-title {
   font-size: 24px;
   font-weight: bold;
   text-align: center;

--- a/src/main/resources/static/js/diary-page.js
+++ b/src/main/resources/static/js/diary-page.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const textarea = document.getElementById('diary-detail-content');
+  const textarea = document.getElementById('diary-page-content');
   const titleInput = document.getElementById('diary-title-input');
 
   if (textarea) {

--- a/src/main/resources/templates/diary-page.html
+++ b/src/main/resources/templates/diary-page.html
@@ -11,9 +11,17 @@
       <a th:href="@{'/' + ${username} + '/task-top/diary-box'}">一覧へ戻る</a>
     </div>
 
+    <div class="diary-title">
+      <input
+        type="text"
+        id="diary-title-input"
+        th:value="${record != null ? record.content : ''}" />
+    </div>
 
     <div class="page-container">
-      <textarea id="diary-detail-content" th:text="${record.detail}"></textarea>
+      <textarea
+        id="diary-page-content"
+        th:text="${record.detail}"></textarea>
     </div>
 
     <script th:src="@{/js/diary-page.js}"></script>


### PR DESCRIPTION
## Summary
- Add title input and rearrange layout for diary detail page to mirror awareness page
- Update diary page script for new element names
- Share title styling between awareness and diary pages

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689aad00f598832a8bf9eadf46c0de40